### PR TITLE
MqttNetSourceLogger with IsEnabled property and use it on hot-paths

### DIFF
--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -132,7 +132,10 @@ namespace MQTTnet.Adapter
 
                     Interlocked.Add(ref _bytesReceived, packetData.Count);
 
-                    _logger.Verbose("TX ({0} bytes) >>> {1}", packetData.Count, packet);
+                    if (_logger.IsEnabled)
+                    {
+                        _logger.Verbose("TX ({0} bytes) >>> {1}", packetData.Count, packet);
+                    }
                 }
                 catch (Exception exception)
                 {
@@ -180,7 +183,10 @@ namespace MQTTnet.Adapter
                     throw new MqttProtocolViolationException("Received malformed packet.");
                 }
 
-                _logger.Verbose("RX ({0} bytes) <<< {1}", receivedPacket.TotalLength, packet);
+                if (_logger.IsEnabled)
+                {
+                    _logger.Verbose("RX ({0} bytes) <<< {1}", receivedPacket.TotalLength, packet);
+                }
 
                 return packet;
             }

--- a/Source/MQTTnet/Diagnostics/Logger/MqttNetSourceLogger.cs
+++ b/Source/MQTTnet/Diagnostics/Logger/MqttNetSourceLogger.cs
@@ -6,12 +6,16 @@ namespace MQTTnet.Diagnostics.Logger
     {
         readonly IMqttNetLogger _logger;
         readonly string _source;
+        readonly bool _isEnabled;
 
         public MqttNetSourceLogger(IMqttNetLogger logger, string source)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _source = source;
+            _isEnabled = logger is not MqttNetNullLogger;
         }
+
+        public bool IsEnabled => _isEnabled;
 
         public void Publish(MqttNetLogLevel logLevel, string message, object[] parameters, Exception exception)
         {

--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -1,4 +1,4 @@
-﻿#if !WINDOWS_UWP
+#if !WINDOWS_UWP
 using MQTTnet.Adapter;
 using MQTTnet.Diagnostics;
 using MQTTnet.Formatter;
@@ -147,10 +147,13 @@ namespace MQTTnet.Implementations
             {
                 remoteEndPoint = clientSocket.RemoteEndPoint.ToString();
 
-                _logger.Verbose("Client '{0}' accepted by TCP listener '{1}, {2}'.",
-                    remoteEndPoint,
-                    _localEndPoint,
-                    _addressFamily == AddressFamily.InterNetwork ? "ipv4" : "ipv6");
+                if (_logger.IsEnabled)
+                {
+                    _logger.Verbose("Client '{0}' accepted by TCP listener '{1}, {2}'.",
+                        remoteEndPoint,
+                        _localEndPoint,
+                        _addressFamily == AddressFamily.InterNetwork ? "ipv4" : "ipv6");
+                }
 
                 clientSocket.NoDelay = _options.NoDelay;
                 stream = clientSocket.GetStream();
@@ -218,10 +221,13 @@ namespace MQTTnet.Implementations
                 }
             }
 
-            _logger.Verbose("Client '{0}' disconnected at TCP listener '{1}, {2}'.",
-                remoteEndPoint,
-                _localEndPoint,
-                _addressFamily == AddressFamily.InterNetwork ? "ipv4" : "ipv6");
+            if (_logger.IsEnabled)
+            {
+                _logger.Verbose("Client '{0}' disconnected at TCP listener '{1}, {2}'.",
+                    remoteEndPoint,
+                    _localEndPoint,
+                    _addressFamily == AddressFamily.InterNetwork ? "ipv4" : "ipv6");
+            }
         }
     }
 }

--- a/Source/MQTTnet/MQTTnet.csproj
+++ b/Source/MQTTnet/MQTTnet.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
@@ -7,6 +7,7 @@
     <AssemblyName>MQTTnet</AssemblyName>
     <RootNamespace>MQTTnet</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <LangVersion>9</LangVersion>
     <Company />
     <Product />
     <Description />

--- a/Source/MQTTnet/Server/Internal/MqttClientConnection.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientConnection.cs
@@ -279,7 +279,10 @@ namespace MQTTnet.Server.Internal
                         }
                     }
 
-                    _logger.Verbose("Client '{0}': Queued application message sent.", ClientId);
+                    if (_logger.IsEnabled)
+                    {
+                        _logger.Verbose("Client '{0}': Queued application message sent.", ClientId);
+                    }
                 }
             }
             catch (OperationCanceledException)

--- a/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
@@ -311,7 +311,10 @@ namespace MQTTnet.Server.Internal
 
             session?.Dispose();
 
-            _logger.Verbose("Session for client '{0}' deleted.", clientId);
+            if (_logger.IsEnabled)
+            {
+                _logger.Verbose("Session for client '{0}' deleted.", clientId);
+            }
         }
 
         public void Dispose()
@@ -414,8 +417,11 @@ namespace MQTTnet.Server.Internal
                         continue;
                     }
 
-                    _logger.Verbose("Client '{0}': Queued application message with topic '{1}'.",
-                        clientSession.ClientId, applicationMessage.Topic);
+                    if (_logger.IsEnabled)
+                    {
+                        _logger.Verbose("Client '{0}': Queued application message with topic '{1}'.",
+                            clientSession.ClientId, applicationMessage.Topic);
+                    }
 
                     var queuedApplicationMessage = new MqttQueuedApplicationMessage
                     {
@@ -527,19 +533,28 @@ namespace MQTTnet.Server.Internal
                 {
                     if (!_clientSessions.TryGetValue(connectPacket.ClientId, out session))
                     {
-                        _logger.Verbose("Created a new session for client '{0}'.", connectPacket.ClientId);
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Verbose("Created a new session for client '{0}'.", connectPacket.ClientId);
+                        }
                         session = CreateSession(connectPacket.ClientId, context.SessionItems, sessionShouldPersist);
                     }
                     else
                     {
                         if (connectPacket.CleanSession)
                         {
-                            _logger.Verbose("Deleting existing session of client '{0}'.", connectPacket.ClientId);
+                            if (_logger.IsEnabled)
+                            {
+                                _logger.Verbose("Deleting existing session of client '{0}'.", connectPacket.ClientId);
+                            }
                             session = CreateSession(connectPacket.ClientId, context.SessionItems, sessionShouldPersist);
                         }
                         else
                         {
-                            _logger.Verbose("Reusing existing session of client '{0}'.", connectPacket.ClientId);
+                            if (_logger.IsEnabled)
+                            {
+                                _logger.Verbose("Reusing existing session of client '{0}'.", connectPacket.ClientId);
+                            }
                             // Session persistence could change for MQTT 5 clients that reconnect with different SessionExpiryInterval
                             session.IsPersistent = sessionShouldPersist;
                             connAckPacket.IsSessionPresent = true;

--- a/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -74,7 +74,10 @@ namespace MQTTnet.Server.Internal
                     if (!hasPayload)
                     {
                         saveIsRequired = _messages.Remove(applicationMessage.Topic);
-                        _logger.Verbose("Client '{0}' cleared retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Verbose("Client '{0}' cleared retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                        }
                     }
                     else
                     {
@@ -92,7 +95,10 @@ namespace MQTTnet.Server.Internal
                             }
                         }
 
-                        _logger.Verbose("Client '{0}' set retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                        if (_logger.IsEnabled)
+                        {
+                            _logger.Verbose("Client '{0}' set retained message for topic '{1}'.", clientId, applicationMessage.Topic);
+                        }
                     }
 
                     if (saveIsRequired)


### PR DESCRIPTION
## Description

With that change the call to `_logger` is only done, when not the null-logger is used.
So valuetype arguments don't get boxed, and the arguments-array doesn't need to be allocated.

The change is applied not to all calls to `_logger`, only on hot-paths.
So connection, disconnections, and exception handling is covered by that change, to keep the code concise.

## Results

### Setup

Server / broker runs in a virtual machine, so to have some network latency, but not too much.
Client publishes 100.000 messages.

<details>
  <summary>Client code</summary>

```c#
using MQTTnet;
using MQTTnet.Client;
using MQTTnet.Client.Options;

public sealed class Worker : BackgroundService
{
    private const int Iterations = 100_000;

    private readonly IHostApplicationLifetime _applicationLifetime;

    public Worker(IHostApplicationLifetime hostApplicationLifetime)
    {
        _applicationLifetime = hostApplicationLifetime;
    }

    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
    {
        byte[] payload = new byte[100];
        Random.Shared.NextBytes(payload);

        IMqttClientOptions mqttClientOptions = new MqttClientOptionsBuilder()
            .WithClientId("client1")
            .WithTcpServer("10.0.0.20")
            .Build();

        using IMqttClient mqttClient = new MqttFactory().CreateMqttClient();

        await mqttClient.ConnectAsync(mqttClientOptions, stoppingToken);

        MqttApplicationMessage publishMessage = new MqttApplicationMessageBuilder()
            .WithTopic("test")
            .WithPayload(payload)
            .Build();

        for (int i = 0; i < Iterations; ++i)
        {
            await mqttClient.PublishAsync(publishMessage, stoppingToken);
        }

        await mqttClient.DisconnectAsync(stoppingToken);

        _applicationLifetime.StopApplication();
    }
}
```
</details>

### Baseline

Profile is based on 5e5818d7df78de6a0a1342c9dca692346f70ad97

![baseline](https://user-images.githubusercontent.com/5755834/148063136-5405c692-9e38-4028-91a1-5759e3d64ca9.png)

### PR

![perf_01](https://user-images.githubusercontent.com/5755834/148064125-8f335e79-9707-4093-a917-ba1453cb74bb.png)

One can see that the ~100.000 allocations for the `object[]` (= args for the logger), and the ~100.000 boxing of `int` is gone.

Side note: the time shown also decreased (as expected), but I wouldn't count on this as it's a allocation profile.