### PR TITLE
Adjusted default value for the supported Net frameworks versions where "None" is incompatible.

### DIFF
--- a/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttChannel.cs
+++ b/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttChannel.cs
@@ -52,6 +52,12 @@ namespace MQTTnet.Extensions.WebSocket4Net
                 }
             }
 
+#if NET452 || NET46 || NET461 || NET462
+        var sslProtocols = _webSocketOptions?.TlsOptions?.SslProtocol ?? SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+#else
+        var sslProtocols = _webSocketOptions?.TlsOptions?.SslProtocol ?? SslProtocols.None;
+#endif
+
             var sslProtocols = _webSocketOptions?.TlsOptions?.SslProtocol ?? SslProtocols.None;
             var subProtocol = _webSocketOptions.SubProtocols.FirstOrDefault() ?? string.Empty;
 

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilderTlsParameters.cs
@@ -19,7 +19,11 @@ namespace MQTTnet.Client.Options
 
         public Func<MqttClientCertificateValidationCallbackContext, bool> CertificateValidationHandler { get; set; }
 
+#if NET452 || NET46 || NET461 || NET462
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+#else
         public SslProtocols SslProtocol { get; set; } = SslProtocols.None;
+#endif
 
 #if WINDOWS_UWP
         public IEnumerable<IEnumerable<byte>> Certificates { get; set; }

--- a/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
@@ -26,7 +26,11 @@ namespace MQTTnet.Client.Options
         public List<SslApplicationProtocol> ApplicationProtocols { get; set; }
 #endif
 
+#if NET452 || NET46 || NET461 || NET462
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+#else
         public SslProtocols SslProtocol { get; set; } = SslProtocols.None;
+#endif
 
         [Obsolete("This property will be removed soon. Use CertificateValidationHandler instead.")]
         public Func<X509Certificate, X509Chain, SslPolicyErrors, IMqttClientOptions, bool> CertificateValidationCallback { get; set; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/MQTTnet/issues/1347.

However, I don't know whether NetStandard or UWP or something is concerned here, too.