### PR TITLE
Allow to change cipher suite

### DIFF
--- a/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
@@ -29,6 +29,8 @@ namespace MQTTnet.Client
 
 #if NETCOREAPP3_1 || NET5_0_OR_GREATER
         public List<System.Net.Security.SslApplicationProtocol> ApplicationProtocols { get; set; }
+        
+        public System.Net.Security.CipherSuitesPolicy CipherSuitesPolicy { get; set; }
 #endif
 
 #if NET48 || NETCOREAPP3_1 || NET5 || NET6

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -104,7 +104,8 @@ namespace MQTTnet.Implementations
                             ClientCertificates = LoadCertificates(),
                             EnabledSslProtocols = _tcpOptions.TlsOptions.SslProtocol,
                             CertificateRevocationCheckMode = _tcpOptions.TlsOptions.IgnoreCertificateRevocationErrors ? X509RevocationMode.NoCheck : X509RevocationMode.Online,
-                            TargetHost = _tcpOptions.Server
+                            TargetHost = _tcpOptions.Server,
+                            CipherSuitesPolicy = _tcpOptions.TlsOptions.CipherSuitesPolicy
                         };
 
                         await sslStream.AuthenticateAsClientAsync(sslOptions, cancellationToken).ConfigureAwait(false);

--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -178,7 +178,7 @@ namespace MQTTnet.Implementations
                 {
                     var sslStream = new SslStream(stream, false, _tlsOptions.RemoteCertificateValidationCallback);
 
-                    #if NETCOREAPP3_0_OR_GREATER
+                    #if NETCOREAPP3_1 || NET5_0_OR_GREATER
                         await sslStream.AuthenticateAsServerAsync(
                             new SslServerAuthenticationOptions()
                             {

--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -188,7 +188,7 @@ namespace MQTTnet.Implementations
                                 CertificateRevocationCheckMode = _tlsOptions.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
                                 EncryptionPolicy = EncryptionPolicy.RequireEncryption,
                                 CipherSuitesPolicy = _tlsOptions.CipherSuitesPolicy
-                            });
+                            }).ConfigureAwait(false);
                     #else
                         await sslStream.AuthenticateAsServerAsync(
                             _tlsCertificate,

--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -178,11 +178,24 @@ namespace MQTTnet.Implementations
                 {
                     var sslStream = new SslStream(stream, false, _tlsOptions.RemoteCertificateValidationCallback);
 
-                    await sslStream.AuthenticateAsServerAsync(
-                        _tlsCertificate,
-                        _tlsOptions.ClientCertificateRequired,
-                        _tlsOptions.SslProtocol,
-                        _tlsOptions.CheckCertificateRevocation).ConfigureAwait(false);
+                    #if NETCOREAPP3_0_OR_GREATER
+                        await sslStream.AuthenticateAsServerAsync(
+                            new SslServerAuthenticationOptions()
+                            {
+                                ServerCertificate = _tlsCertificate,
+                                ClientCertificateRequired = _tlsOptions.ClientCertificateRequired,
+                                EnabledSslProtocols = _tlsOptions.SslProtocol,
+                                CertificateRevocationCheckMode = _tlsOptions.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+                                EncryptionPolicy = EncryptionPolicy.RequireEncryption,
+                                CipherSuitesPolicy = _tlsOptions.CipherSuitesPolicy
+                            });
+                    #else
+                        await sslStream.AuthenticateAsServerAsync(
+                            _tlsCertificate,
+                            _tlsOptions.ClientCertificateRequired,
+                            _tlsOptions.SslProtocol,
+                            _tlsOptions.CheckCertificateRevocation).ConfigureAwait(false);
+                    #endif
 
                     stream = sslStream;
 

--- a/Source/MQTTnet/Server/Options/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/Options/MqttServerTlsTcpEndpointOptions.cs
@@ -25,7 +25,7 @@ namespace MQTTnet.Server
 
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
         
-#if NETCOREAPP3_0_OR_GREATER
+#if NETCOREAPP3_1 || NET5_0_OR_GREATER
         public System.Net.Security.CipherSuitesPolicy CipherSuitesPolicy { get; set; }
 #endif
     }

--- a/Source/MQTTnet/Server/Options/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet/Server/Options/MqttServerTlsTcpEndpointOptions.cs
@@ -24,5 +24,9 @@ namespace MQTTnet.Server
         public bool CheckCertificateRevocation { get; set; }
 
         public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
+        
+#if NETCOREAPP3_0_OR_GREATER
+        public System.Net.Security.CipherSuitesPolicy CipherSuitesPolicy { get; set; }
+#endif
     }
 }


### PR DESCRIPTION
Hi,

i have added an optional option to allow to set the used Cipher Suite for the TLS communication (server and client).

This is necessary in my case, because my MQTT devices (which I cant change/update) use and older cipher suite than the default values.

Microsoft changed the default values in .NET 5.0 and that means my devices work with .NET CORE 3.1 but not with .NET 6.0
https://docs.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/default-cipher-suites-for-tls-on-linux
