### PR TITLE
Add List of TopicFilters when getting Retained messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,17 +30,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Setup Signing Certificate
-        run: |
-          $secret = '${{ secrets.SNC_BASE64 }}'
-          $decoded = [System.Convert]::FromBase64CharArray($secret, 0, $secret.Length)
-          Set-Content -Path ${{ github.workspace }}\certificate.snk -Value $decoded -AsByteStream
-
       - name: Restore nuget packages
         run: msbuild MQTTnet.sln /t:Restore /p:Configuration="Release" /verbosity:m
 
       - name: Build solution
-        run: msbuild MQTTnet.sln /t:Build /p:Configuration="Release" /verbosity:m /p:FileVersion=${{ env.ASSEMBLY_VERSION }} /p:AssemblyVersion=${{ env.ASSEMBLY_VERSION }} /p:PackageVersion=${{ env.NUGET_VERSION }} /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=${{ github.workspace }}\certificate.snk
+        run: msbuild MQTTnet.sln /t:Build /p:Configuration="Release" /verbosity:m /p:FileVersion=${{ env.ASSEMBLY_VERSION }} /p:AssemblyVersion=${{ env.ASSEMBLY_VERSION }} /p:PackageVersion=${{ env.NUGET_VERSION }}
 
       - name: Collect nuget Packages
         uses: actions/upload-artifact@v2
@@ -58,10 +52,6 @@ jobs:
 
       - name: ASP.NET Tests
         run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
-
-      - name: Publish MyGet nugets
-        if: ${{ github.event_name == 'push' }}
-        run: dotnet nuget push **/*.nupkg -k ${{ secrets.MYGET_API_KEY }} -s https://www.myget.org/F/mqttnet/api/v3/index.json --skip-duplicate
 
 #      - name: Publish nugets
 #        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
       - name: ASP.NET Tests
         run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
 
-#      - name: Publish nugets
-#        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-#        run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Publish nugets
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://nuget.pkg.github.com/yarektyshchenko/index.json --skip-duplicate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
-on: [push, pull_request]
+# on: [push, pull_request]
+on: [push]
 
 env:
   ASSEMBLY_VERSION: "4.0.0.${{github.run_number}}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
         run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
 
       - name: Publish nugets
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        #if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://nuget.pkg.github.com/yarektyshchenko/index.json --skip-duplicate

--- a/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
+++ b/Source/MQTTnet.AspnetCore/MQTTnet.AspNetCore.csproj
@@ -18,7 +18,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Copyright>Christian Kratky 2016-2022</Copyright>
         <PackageProjectUrl>https://github.com/dotnet/MQTTnet</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/dotnet/MQTTnet.git</RepositoryUrl>
+        <RepositoryUrl>https://github.com/yarektyshchenko/MQTTnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor</PackageTags>
         <NeutralLanguage>en-US</NeutralLanguage>

--- a/Source/MQTTnet.Extensions.ManagedClient/MQTTnet.Extensions.ManagedClient.csproj
+++ b/Source/MQTTnet.Extensions.ManagedClient/MQTTnet.Extensions.ManagedClient.csproj
@@ -20,7 +20,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Copyright>Christian Kratky 2016-2022</Copyright>
         <PackageProjectUrl>https://github.com/dotnet/MQTTnet</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/dotnet/MQTTnet.git</RepositoryUrl>
+        <RepositoryUrl>https://github.com/yarektyshchenko/MQTTnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor</PackageTags>
         <NeutralLanguage>en-US</NeutralLanguage>

--- a/Source/MQTTnet.Extensions.Rpc/MQTTnet.Extensions.Rpc.csproj
+++ b/Source/MQTTnet.Extensions.Rpc/MQTTnet.Extensions.Rpc.csproj
@@ -20,7 +20,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Copyright>Christian Kratky 2016-2022</Copyright>
         <PackageProjectUrl>https://github.com/dotnet/MQTTnet</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/dotnet/MQTTnet.git</RepositoryUrl>
+        <RepositoryUrl>https://github.com/yarektyshchenko/MQTTnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor</PackageTags>
         <NeutralLanguage>en-US</NeutralLanguage>

--- a/Source/MQTTnet.Extensions.WebSocket4Net/MQTTnet.Extensions.WebSocket4Net.csproj
+++ b/Source/MQTTnet.Extensions.WebSocket4Net/MQTTnet.Extensions.WebSocket4Net.csproj
@@ -20,7 +20,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Copyright>Christian Kratky 2016-2022</Copyright>
         <PackageProjectUrl>https://github.com/dotnet/MQTTnet</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/dotnet/MQTTnet.git</RepositoryUrl>
+        <RepositoryUrl>https://github.com/yarektyshchenko/MQTTnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor</PackageTags>
         <NeutralLanguage>en-US</NeutralLanguage>

--- a/Source/MQTTnet/MQTTnet.csproj
+++ b/Source/MQTTnet/MQTTnet.csproj
@@ -31,7 +31,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Copyright>Christian Kratky 2016-2022</Copyright>
         <PackageProjectUrl>https://github.com/dotnet/MQTTnet</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/dotnet/MQTTnet.git</RepositoryUrl>
+        <RepositoryUrl>https://github.com/yarektyshchenko/MQTTnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>MQTT Message Queue Telemetry Transport MQTTClient MQTTServer Server MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor</PackageTags>
         <NeutralLanguage>en-US</NeutralLanguage>

--- a/Source/MQTTnet/Server/Internal/MqttClientSubscriptionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSubscriptionsManager.cs
@@ -168,7 +168,9 @@ namespace MQTTnet.Server
                 throw new ArgumentNullException(nameof(subscribePacket));
             }
 
-            var retainedApplicationMessages = await _retainedMessagesManager.GetMessages().ConfigureAwait(false);
+            var retainedApplicationMessages = await _retainedMessagesManager
+                .GetMessages(subscribePacket.TopicFilters)
+                .ConfigureAwait(false);
             var result = new SubscribeResult
             {
                 ReasonCodes = new List<MqttSubscribeReasonCode>(subscribePacket.TopicFilters.Count)

--- a/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
@@ -13,6 +13,8 @@ using MQTTnet.Internal;
 
 namespace MQTTnet.Server
 {
+    using MQTTnet.Packets;
+
     public sealed class MqttRetainedMessagesManager
     {
         readonly Dictionary<string, MqttApplicationMessage> _messages = new Dictionary<string, MqttApplicationMessage>(4096);
@@ -122,7 +124,8 @@ namespace MQTTnet.Server
             }
         }
         
-        public Task<IList<MqttApplicationMessage>> GetMessages()
+        public Task<IList<MqttApplicationMessage>> GetMessages(
+            List<MqttTopicFilter> topicFilters = null)
         {
             lock (_messages)
             {

--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -185,11 +185,11 @@ namespace MQTTnet.Server
             return _clientSessionsManager.GetClientStatusAsync();
         }
 
-        public Task<IList<MqttApplicationMessage>> GetRetainedMessagesAsync()
+        public Task<IList<MqttApplicationMessage>> GetRetainedMessagesAsync(List<MqttTopicFilter> topicFilters = null)
         {
             ThrowIfNotStarted();
 
-            return _retainedMessagesManager.GetMessages();
+            return _retainedMessagesManager.GetMessages(topicFilters);
         }
 
         public Task<IList<MqttSessionStatus>> GetSessionsAsync()


### PR DESCRIPTION
This is so that storage can fetch only the messages that it needs
based on the current subscription, and not all messages.

If the broker is backed by a database, keeping all messages in memory
doesn't make sense. It would be better to call up individual sets of
messages on demand.

See #1286 and https://github.com/dotnet/MQTTnet/issues/1206#issuecomment-887417891