### PR TITLE
Added MqttClientTlsOptions option to control RevocationMode for clients with…

### DIFF
--- a/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientTlsOptions.cs
@@ -21,6 +21,8 @@ namespace MQTTnet.Client
 
         public bool AllowUntrustedCertificates { get; set; }
 
+        public X509RevocationMode RevocationMode { get; set; } = X509RevocationMode.Online;
+
 #if WINDOWS_UWP
         public List<byte[]> Certificates { get; set; }
 #else

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -103,7 +103,7 @@ namespace MQTTnet.Implementations
                             ApplicationProtocols = _tcpOptions.TlsOptions.ApplicationProtocols,
                             ClientCertificates = LoadCertificates(),
                             EnabledSslProtocols = _tcpOptions.TlsOptions.SslProtocol,
-                            CertificateRevocationCheckMode = _tcpOptions.TlsOptions.IgnoreCertificateRevocationErrors ? X509RevocationMode.NoCheck : X509RevocationMode.Online,
+                            CertificateRevocationCheckMode = _tcpOptions.TlsOptions.IgnoreCertificateRevocationErrors ? X509RevocationMode.NoCheck : _tcpOptions.TlsOptions.RevocationMode,
                             TargetHost = _tcpOptions.Server,
                             CipherSuitesPolicy = _tcpOptions.TlsOptions.CipherSuitesPolicy
                         };


### PR DESCRIPTION
… limited Internet access (defaults to Online).

I have some use cases that have no Internet access and having an "Online" RCL is not an option. Being able to control the RecovationMode is a good option to have (so I can set that to Offline instead of ignoring revocation list check alltogether).