### PR TITLE
Use IgnoreCertificateChainErrors option in TcpChannel

### DIFF
--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 #if !WINDOWS_UWP
+using MQTTnet.Channel;
+using MQTTnet.Client;
+using MQTTnet.Exceptions;
 using System;
 using System.IO;
 using System.Net.Security;
@@ -11,9 +14,6 @@ using System.Runtime.ExceptionServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using MQTTnet.Channel;
-using MQTTnet.Client;
-using MQTTnet.Exceptions;
 
 namespace MQTTnet.Implementations
 {
@@ -77,7 +77,7 @@ namespace MQTTnet.Implementations
                 {
                     socket.LingerState = _tcpOptions.LingerState;
                 }
-                
+
                 if (_tcpOptions.DualMode.HasValue)
                 {
                     // It is important to avoid setting the flag if no specific value is set by the user
@@ -268,6 +268,9 @@ namespace MQTTnet.Implementations
 
                 return certificateValidationHandler(eventArgs);
             }
+
+            if (_tcpOptions?.TlsOptions?.IgnoreCertificateChainErrors ?? false)
+                sslPolicyErrors &= ~SslPolicyErrors.RemoteCertificateChainErrors;
 
             return sslPolicyErrors == SslPolicyErrors.None;
         }


### PR DESCRIPTION
The IgnoreCertificateChainErrors was not being used to actually ignore this type of SSL Error in the [MqttTcpChannel](https://github.com/dotnet/MQTTnet/blob/73d681bc1f978c4e6cf03266fcd1fb4a30a5d205/Source/MQTTnet/Implementations/MqttTcpChannel.cs).
The only place i could find that it was being used for .NETCOREAPP 3.1 / .NET 5 or greater was in the [MqttClientDefaultCertificateValidationHandler.cs](https://github.com/dotnet/MQTTnet/blob/73d681bc1f978c4e6cf03266fcd1fb4a30a5d205/Source/MQTTnet/Client/Options/MqttClientDefaultCertificateValidationHandler.cs), but this is not being referenced anywhere.

This PR adds a check for this option and accepts the corresponding SSL Error in the case it is enabled.

I hope I can contribute to this project, and please let me know if I have misunderstood something! :)