### PR TITLE
Fix Exception "Collection was modified"

### DIFF
--- a/Source/MQTTnet/Internal/AsyncEvent.cs
+++ b/Source/MQTTnet/Internal/AsyncEvent.cs
@@ -37,7 +37,7 @@ namespace MQTTnet.Internal
 
         public async Task InvokeAsync(TEventArgs eventArgs)
         {
-            foreach (var handler in _handlers)
+            foreach (var handler in _handlers.ToArray())
             {
                 await handler.InvokeAsync(eventArgs).ConfigureAwait(false);
             }


### PR DESCRIPTION
It leads to Exception "Collection was modified; enumeration operation may not execute." if during execution of InvokeAsync, RemoveHandler is called.
This is the case if we use RxMqttNet.