### PR TITLE
Fail all waiting tasks when the client connection gets closed

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,2 +1,3 @@
 * [Core] Fixed dead lock and race conditions in new _AsyncLock_ implementation (#1542).
 * [Client] Fixed connection freeze when using Xamarin etc.
+* [Client] All waiting tasks will now fail when the client connection gets closed. This fixes several freezes (#1561).

--- a/Source/MQTTnet.Tests/Server/Publishing_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Publishing_Tests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Client;
+using MQTTnet.Protocol;
+
+namespace MQTTnet.Tests.Server
+{
+    [TestClass]
+    public sealed class Publishing_Tests : BaseTestClass
+    {
+        [TestMethod]
+        [ExpectedException(typeof(MqttClientDisconnectedException))]
+        public async Task Disconnect_While_Publishing()
+        {
+            using (var testEnvironment = CreateTestEnvironment())
+            {
+                var server = await testEnvironment.StartServer();
+
+                // The client will be disconnect directly after subscribing!
+                server.InterceptingPublishAsync += ev => server.DisconnectClientAsync(ev.ClientId, MqttDisconnectReasonCode.NormalDisconnection);
+
+                var client = await testEnvironment.ConnectClient();
+                await client.PublishStringAsync("test", qualityOfServiceLevel: MqttQualityOfServiceLevel.AtLeastOnce);
+            }
+        }
+    }
+}

--- a/Source/MQTTnet.Tests/Server/Subscribe_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Subscribe_Tests.cs
@@ -47,6 +47,22 @@ namespace MQTTnet.Tests.Server
         }
 
         [TestMethod]
+        [ExpectedException(typeof(MqttClientDisconnectedException))]
+        public async Task Disconnect_While_Subscribing()
+        {
+            using (var testEnvironment = CreateTestEnvironment())
+            {
+                var server = await testEnvironment.StartServer();
+
+                // The client will be disconnect directly after subscribing!
+                server.ClientSubscribedTopicAsync += ev => server.DisconnectClientAsync(ev.ClientId, MqttDisconnectReasonCode.NormalDisconnection);
+
+                var client = await testEnvironment.ConnectClient();
+                await client.SubscribeAsync("#");
+            }
+        }
+        
+        [TestMethod]
         public async Task Enqueue_Message_After_Subscription()
         {
             using (var testEnvironment = CreateTestEnvironment())

--- a/Source/MQTTnet.Tests/Server/Unsubscribe_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Unsubscribe_Tests.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Client;
+using MQTTnet.Protocol;
+
+namespace MQTTnet.Tests.Server
+{
+    [TestClass]
+    public sealed class Unsubscribe_Tests : BaseTestClass
+    {
+        [TestMethod]
+        [ExpectedException(typeof(MqttClientDisconnectedException))]
+        public async Task Disconnect_While_Unsubscribing()
+        {
+            using (var testEnvironment = CreateTestEnvironment())
+            {
+                var server = await testEnvironment.StartServer();
+
+                // The client will be disconnect directly after subscribing!
+                server.ClientUnsubscribedTopicAsync += ev => server.DisconnectClientAsync(ev.ClientId, MqttDisconnectReasonCode.NormalDisconnection);
+
+                var client = await testEnvironment.ConnectClient();
+                await client.SubscribeAsync("#");
+                await client.UnsubscribeAsync("#");
+            }
+        }
+    }
+}

--- a/Source/MQTTnet/Client/Exceptions/MqttClientDisconnectedException.cs
+++ b/Source/MQTTnet/Client/Exceptions/MqttClientDisconnectedException.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using MQTTnet.Exceptions;
+
+namespace MQTTnet.Client
+{
+    public sealed class MqttClientDisconnectedException : MqttCommunicationException
+    {
+        public MqttClientDisconnectedException(Exception innerException) : base("The MQTT client is disconnected.", innerException)
+        {
+        }
+    }
+}

--- a/Source/MQTTnet/Client/Exceptions/MqttClientUnexpectedDisconnectReceivedException.cs
+++ b/Source/MQTTnet/Client/Exceptions/MqttClientUnexpectedDisconnectReceivedException.cs
@@ -3,14 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using MQTTnet.Exceptions;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
 
-namespace MQTTnet.Exceptions
+namespace MQTTnet.Client
 {
-    public class MqttUnexpectedDisconnectReceivedException : MqttCommunicationException
+    public sealed class MqttClientUnexpectedDisconnectReceivedException : MqttCommunicationException
     {
-        public MqttUnexpectedDisconnectReceivedException(MqttDisconnectPacket disconnectPacket) 
+        public MqttClientUnexpectedDisconnectReceivedException(MqttDisconnectPacket disconnectPacket) 
             : base($"Unexpected DISCONNECT (Reason code={disconnectPacket.ReasonCode}) received.")
         {
             ReasonCode = disconnectPacket.ReasonCode;

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -447,6 +447,8 @@ namespace MQTTnet.Client
 
             try
             {
+                _packetDispatcher.FailAll(new MqttClientDisconnectedException(exception));
+                
                 var receiverTask = WaitForTaskAsync(_packetReceiverTask, sender);
                 var publishPacketReceiverTask = WaitForTaskAsync(_publishPacketReceiverTask, sender);
                 var keepAliveTask = WaitForTaskAsync(_keepAlivePacketsSenderTask, sender);
@@ -558,7 +560,7 @@ namespace MQTTnet.Client
             _disconnectReasonString = disconnectPacket.ReasonString;
 
             // Also dispatch disconnect to waiting threads to generate a proper exception.
-            _packetDispatcher.FailAll(new MqttUnexpectedDisconnectReceivedException(disconnectPacket));
+            _packetDispatcher.FailAll(new MqttClientUnexpectedDisconnectReceivedException(disconnectPacket));
 
             return DisconnectInternalAsync(_packetReceiverTask, null, null);
         }

--- a/Source/MQTTnet/Exceptions/MqttCommunicationException.cs
+++ b/Source/MQTTnet/Exceptions/MqttCommunicationException.cs
@@ -8,12 +8,8 @@ namespace MQTTnet.Exceptions
 {
     public class MqttCommunicationException : Exception
     {
-        protected MqttCommunicationException()
-        {
-        }
-
         public MqttCommunicationException(Exception innerException)
-            : base(innerException.Message, innerException)
+            : base(innerException?.Message ?? "MQTT communication failed.", innerException)
         {
         }
 

--- a/Source/MQTTnet/MQTTnet.csproj.DotSettings
+++ b/Source/MQTTnet/MQTTnet.csproj.DotSettings
@@ -2,6 +2,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=client_005Cconnecting/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=client_005Cdiagnostics/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=client_005Cdisconnecting/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=client_005Cexceptions/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=client_005Cextendedauthenticationexchange/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=client_005Coptions/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=client_005Cpublishing/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This pull request fixes several freezes which may happen when the connection gets closed while the client is subscribing, unsubscribing or publishing.