### PR TITLE
Fix upgrading and downgrading of retained messages QoS for subscriptions

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,2 +1,3 @@
 * [Core] Fixed dead lock and race conditions in new _AsyncLock_ implementation (#1542).
 * [Client] Fixed connection freeze when using Xamarin etc.
+* [Server] Fixed issue in upgrading and downgrading of QoS levels for subscriptions and retained messages (#1560).

--- a/Source/MQTTnet/Formatter/MqttPacketFactories.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketFactories.cs
@@ -7,6 +7,7 @@ namespace MQTTnet.Formatter
     public sealed class MqttPacketFactories
     {
         public MqttConnAckPacketFactory ConnAck { get; } = new MqttConnAckPacketFactory();
+        
         public MqttConnectPacketFactory Connect { get; } = new MqttConnectPacketFactory();
 
         public MqttDisconnectPacketFactory Disconnect { get; } = new MqttDisconnectPacketFactory();

--- a/Source/MQTTnet/Formatter/MqttPublishPacketFactory.cs
+++ b/Source/MQTTnet/Formatter/MqttPublishPacketFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using MQTTnet.Exceptions;
 using MQTTnet.Packets;
+using MQTTnet.Server;
 
 namespace MQTTnet.Formatter
 {
@@ -79,6 +80,18 @@ namespace MQTTnet.Formatter
             };
 
             return packet;
+        }
+
+        public MqttPublishPacket Create(MqttRetainedMessageMatch retainedMessage)
+        {
+            if (retainedMessage == null)
+            {
+                throw new ArgumentNullException(nameof(retainedMessage));
+            }
+
+            var publishPacket = Create(retainedMessage.ApplicationMessage);
+            publishPacket.QualityOfServiceLevel = retainedMessage.SubscriptionQualityOfServiceLevel;
+            return publishPacket;
         }
     }
 }

--- a/Source/MQTTnet/Server/Internal/MqttClient.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClient.cs
@@ -11,7 +11,6 @@ using MQTTnet.Client;
 using MQTTnet.Diagnostics;
 using MQTTnet.Exceptions;
 using MQTTnet.Formatter;
-using MQTTnet.Implementations;
 using MQTTnet.Internal;
 using MQTTnet.PacketDispatcher;
 using MQTTnet.Packets;
@@ -307,14 +306,13 @@ namespace MQTTnet.Server
 
             if (subscribeResult.RetainedMessages != null)
             {
-                foreach (var retainedApplicationMessage in subscribeResult.RetainedMessages)
+                foreach (var retainedMessageMatch in subscribeResult.RetainedMessages)
                 {
-                    var publishPacket = _packetFactories.Publish.Create(retainedApplicationMessage.ApplicationMessage);
+                    var publishPacket = _packetFactories.Publish.Create(retainedMessageMatch);
                     Session.EnqueueDataPacket(new MqttPacketBusItem(publishPacket));
                 }
             }
         }
-
 
         async Task HandleIncomingUnsubscribePacket(MqttUnsubscribePacket unsubscribePacket, CancellationToken cancellationToken)
         {

--- a/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
@@ -418,9 +418,9 @@ namespace MQTTnet.Server
 
             if (subscribeResult.RetainedMessages != null)
             {
-                foreach (var retainedApplicationMessage in subscribeResult.RetainedMessages)
+                foreach (var retainedMessageMatch in subscribeResult.RetainedMessages)
                 {
-                    var publishPacket = _packetFactories.Publish.Create(retainedApplicationMessage.ApplicationMessage);
+                    var publishPacket = _packetFactories.Publish.Create(retainedMessageMatch);
                     clientSession.EnqueueDataPacket(new MqttPacketBusItem(publishPacket));
                 }
             }

--- a/Source/MQTTnet/Server/Internal/SubscribeResult.cs
+++ b/Source/MQTTnet/Server/Internal/SubscribeResult.cs
@@ -10,8 +10,13 @@ namespace MQTTnet.Server
 {
     public sealed class SubscribeResult
     {
+        public SubscribeResult(int topicsCount)
+        {
+            ReasonCodes = new List<MqttSubscribeReasonCode>(topicsCount);
+        }
+        
         public bool CloseConnection { get; set; }
-
+        
         public List<MqttSubscribeReasonCode> ReasonCodes { get; set; }
 
         public string ReasonString { get; set; }

--- a/Source/MQTTnet/Server/MqttRetainedMessageMatch.cs
+++ b/Source/MQTTnet/Server/MqttRetainedMessageMatch.cs
@@ -2,13 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using MQTTnet.Protocol;
 
 namespace MQTTnet.Server
 {
     public sealed class MqttRetainedMessageMatch
     {
-        public MqttApplicationMessage ApplicationMessage { get; set; }
+        public MqttRetainedMessageMatch(MqttApplicationMessage applicationMessage, MqttQualityOfServiceLevel subscriptionQualityOfServiceLevel)
+        {
+            ApplicationMessage = applicationMessage ?? throw new ArgumentNullException(nameof(applicationMessage));
+            SubscriptionQualityOfServiceLevel = subscriptionQualityOfServiceLevel;
+        }
+
+        public MqttApplicationMessage ApplicationMessage { get; }
 
         public MqttQualityOfServiceLevel SubscriptionQualityOfServiceLevel { get; set; }
     }


### PR DESCRIPTION
This pull request fixes the upgrade and downgrade handling of the QoS level for retained messages when subscribing.