### PR TITLE
Optimize SendPacketAsync method for MQTTnet.AspNetCore

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -31,7 +31,7 @@ namespace MQTTnet.AspNetCore
             Connection = connection ?? throw new ArgumentNullException(nameof(connection));
 
             var feature = connection.Features.Get<IHttpContextFeature>();
-            if (feature != null)
+            if (feature != null && feature.HttpContext != null)
             {
                 _isOverWebSocket = feature.HttpContext.WebSockets.IsWebSocketRequest;
             }

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -8,23 +8,23 @@ using MQTTnet.Adapter;
 using MQTTnet.AspNetCore.Client.Tcp;
 using MQTTnet.Exceptions;
 using MQTTnet.Formatter;
+using MQTTnet.Internal;
 using MQTTnet.Packets;
 using System;
 using System.IO.Pipelines;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using MQTTnet.Internal;
 
 namespace MQTTnet.AspNetCore
 {
     public sealed class MqttConnectionContext : IMqttChannelAdapter
     {
         readonly AsyncLock _writerLock = new AsyncLock();
-        
+
         PipeReader _input;
         PipeWriter _output;
-        
+
         public MqttConnectionContext(MqttPacketFormatterAdapter packetFormatterAdapter, ConnectionContext connection)
         {
             PacketFormatterAdapter = packetFormatterAdapter ?? throw new ArgumentNullException(nameof(packetFormatterAdapter));
@@ -62,7 +62,7 @@ namespace MQTTnet.AspNetCore
         public X509Certificate2 ClientCertificate => Http?.HttpContext?.Connection?.ClientCertificate;
 
         public ConnectionContext Connection { get; }
-        
+
         public MqttPacketFormatterAdapter PacketFormatterAdapter { get; }
 
         public long BytesSent { get; set; }
@@ -169,19 +169,17 @@ namespace MQTTnet.AspNetCore
 
         public async Task SendPacketAsync(MqttPacket packet, CancellationToken cancellationToken)
         {
-            var formatter = PacketFormatterAdapter;
-            
             using (await _writerLock.EnterAsync(cancellationToken).ConfigureAwait(false))
             {
-                var buffer = formatter.Encode(packet);
-                var msg = buffer.Join().AsMemory();
-                var output = _output;
-                var result = await output.WriteAsync(msg, cancellationToken).ConfigureAwait(false);
-                if (result.IsCompleted)
+                var buffer = PacketFormatterAdapter.Encode(packet);
+                await _output.WriteAsync(buffer.Packet, cancellationToken).ConfigureAwait(false);
+
+                if (buffer.Payload.Count > 0)
                 {
-                    BytesSent += msg.Length;
+                    await _output.WriteAsync(buffer.Payload, cancellationToken).ConfigureAwait(false);
                 }
 
+                BytesSent += buffer.Length;
                 PacketFormatterAdapter.Cleanup();
             }
         }

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -171,16 +171,22 @@ namespace MQTTnet.AspNetCore
         {
             using (await _writerLock.EnterAsync(cancellationToken).ConfigureAwait(false))
             {
-                var buffer = PacketFormatterAdapter.Encode(packet);
-                await _output.WriteAsync(buffer.Packet, cancellationToken).ConfigureAwait(false);
-
-                if (buffer.Payload.Count > 0)
+                try
                 {
-                    await _output.WriteAsync(buffer.Payload, cancellationToken).ConfigureAwait(false);
-                }
+                    var buffer = PacketFormatterAdapter.Encode(packet);
+                    await _output.WriteAsync(buffer.Packet, cancellationToken).ConfigureAwait(false);
 
-                BytesSent += buffer.Length;
-                PacketFormatterAdapter.Cleanup();
+                    if (buffer.Payload.Count > 0)
+                    {
+                        await _output.WriteAsync(buffer.Payload, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    BytesSent += buffer.Length;
+                }
+                finally
+                {
+                    PacketFormatterAdapter.Cleanup();
+                }
             }
         }
 


### PR DESCRIPTION
1. [Avoid to call MqttPacketBuffer.Join() when SendPacketAsync](https://github.com/dotnet/MQTTnet/commit/a2127c68fd86692979031871bc51af969e8b6c7c)
2. [Safely cleanup the PacketFormatterAdapter](https://github.com/dotnet/MQTTnet/commit/df8e78a50b31124c361c7fdb0f2ca1e6c06542d9)