### PR TITLE
Set string.Empty as default value for SenderClientId

### DIFF
--- a/Source/MQTTnet/Server/InjectedMqttApplicationMessage.cs
+++ b/Source/MQTTnet/Server/InjectedMqttApplicationMessage.cs
@@ -12,8 +12,8 @@ namespace MQTTnet.Server
         {
             ApplicationMessage = applicationMessage ?? throw new ArgumentNullException(nameof(applicationMessage));
         }
-        
-        public string SenderClientId { get; set; }
+
+        public string SenderClientId { get; set; } = string.Empty;
 
         public MqttApplicationMessage ApplicationMessage { get; set; }
     }


### PR DESCRIPTION
As me konw, when the property `SenderClientId ` of `InjectedMqttApplicationMessage` type is null, `MqttServer. InjectApplicationMessage (InjectedMqttApplicationMessage)` will throws an `ArgumentNullException`. Unfortunately,  `MqttServerExtensions.cs` provide extension methods without the SenderClientId parameter, it allway throw `ArgumentNullException`.

```c#
public static Task InjectApplicationMessage(
    this MqttServer server,
    string topic,
    string payload = null,
    MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtMostOnce,
    bool retain = false)
```
So we might as well give the `SenderClientId`  property to set the default value of `string.Empty`