### PR TITLE
Dispose the AsyncSignalWaiter before setting it to null

### DIFF
--- a/Source/MQTTnet/Internal/AsyncSignal.cs
+++ b/Source/MQTTnet/Internal/AsyncSignal.cs
@@ -39,6 +39,7 @@ namespace MQTTnet.Internal
                 if (_waiter != null)
                 {
                     _waiter.Approve();
+                    _waiter.Dispose();
                     _waiter = null;
 
                     // Since we already got a waiter the signal must be reset right now!


### PR DESCRIPTION
Fixes a memory leak within `AsyncSignalWaiter` when setting the signal on an `AsyncSignal` instance. See #1584 for more details.