### PR TITLE
Avoid to check the type of propertyWriter parameter

### DIFF
--- a/Source/MQTTnet/Formatter/MqttBufferWriter.cs
+++ b/Source/MQTTnet/Formatter/MqttBufferWriter.cs
@@ -66,7 +66,7 @@ namespace MQTTnet.Formatter
         public static int GetVariableByteIntegerSize(uint value)
         {
             // From RFC: Table 2.4 Size of Remaining Length field
-        
+
             // 0 (0x00) to 127 (0x7F)
             if (value <= 127)
             {
@@ -103,18 +103,12 @@ namespace MQTTnet.Formatter
 
         public void Write(MqttBufferWriter propertyWriter)
         {
-            if (propertyWriter is MqttBufferWriter writer)
-            {
-                WriteBinary(writer._buffer, 0, writer.Length);
-                return;
-            }
-
             if (propertyWriter == null)
             {
                 throw new ArgumentNullException(nameof(propertyWriter));
             }
 
-            throw new InvalidOperationException($"{nameof(propertyWriter)} must be of type {nameof(MqttBufferWriter)}");
+            WriteBinary(propertyWriter._buffer, 0, propertyWriter.Length);
         }
 
         public void WriteBinary(byte[] buffer, int offset, int count)


### PR DESCRIPTION
`MqttBufferWriter` is a sealed class, so we should avoid to check the type of  propertyWriter in `Write(MqttBufferWriter propertyWriter)`