### PR TITLE
Added server extensibility interface

### DIFF
--- a/Source/MQTTnet/Server/Internal/IMqttServerExtensibility.cs
+++ b/Source/MQTTnet/Server/Internal/IMqttServerExtensibility.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MQTTnet.Server
+{
+    public interface IMqttServerExtensibility
+    {
+
+        MqttClientSessionsManager MqttClientSessionsManager { get; }
+
+        IDictionary SessionItems { get; }
+
+    }
+}

--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -17,7 +17,7 @@ using MQTTnet.Protocol;
 
 namespace MQTTnet.Server
 {
-    public class MqttServer : Disposable
+    public class MqttServer : Disposable, IMqttServerExtensibility
     {
         readonly ICollection<IMqttServerAdapter> _adapters;
         readonly MqttClientSessionsManager _clientSessionsManager;
@@ -166,6 +166,11 @@ namespace MQTTnet.Server
         }
 
         public bool IsStarted => _cancellationTokenSource != null;
+
+        MqttClientSessionsManager IMqttServerExtensibility.MqttClientSessionsManager => _clientSessionsManager;
+
+        IDictionary IMqttServerExtensibility.SessionItems => _sessionItems;
+
 
         public Task DeleteRetainedMessagesAsync()
         {


### PR DESCRIPTION
The MQTT protocol is used almost unanimously for connecting IoT devices. In many cases the messages being sent in either direction (cloud-to-device or device-to-cloud) are routed to topics which include the client id or some other form of individual device identifier. In many cases, messages are routed in exclusively this manner.

The nature of most clustered MQTT brokers is to replicate messages across all nodes so every connected client has the ability to receive the message for that topic if they are subscribed to it. Including the ability for developers to inject messages on topics directed to specific clients has the advantage of increasing performance when scanning the list of sessions/clients to relay messages to.

Leveraging the combination of these changes and cancelling ProcessPublish during the InterceptingPublishAsync method, users of this library can customize the routes of their messages to go directly to the individual client they intended.

In load balanced / clustered scenarios with millions of connected devices, this has a massive advantage.