### PR TITLE
Performance impact fix

### DIFF
--- a/Source/MQTTnet/Server/Internal/MqttClientSubscriptionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSubscriptionsManager.cs
@@ -403,23 +403,23 @@ namespace MQTTnet.Server
             CreateSubscriptionResult createSubscriptionResult,
             SubscribeResult subscribeResult)
         {
+            if (createSubscriptionResult.Subscription.RetainHandling == MqttRetainHandling.DoNotSendOnSubscribe)
+            {
+                // This is a MQTT V5+ feature.
+                return;
+                }
+
+            if (createSubscriptionResult.Subscription.RetainHandling == MqttRetainHandling.SendAtSubscribeIfNewSubscriptionOnly && !createSubscriptionResult.IsNewSubscription)
+                {
+                    // This is a MQTT V5+ feature.
+                return;
+                }
+
             for (var index = retainedMessages.Count - 1; index >= 0; index--)
             {
                 var retainedMessage = retainedMessages[index];
                 if (retainedMessage == null)
                 {
-                    continue;
-                }
-
-                if (createSubscriptionResult.Subscription.RetainHandling == MqttRetainHandling.DoNotSendOnSubscribe)
-                {
-                    // This is a MQTT V5+ feature.
-                    continue;
-                }
-
-                if (createSubscriptionResult.Subscription.RetainHandling == MqttRetainHandling.SendAtSubscribeIfNewSubscriptionOnly && !createSubscriptionResult.IsNewSubscription)
-                {
-                    // This is a MQTT V5+ feature.
                     continue;
                 }
 


### PR DESCRIPTION
In my opinion, the MQTTv5 functions "DoNotSendOnSubscribe" and "SendAtSubscribeIfNewSubscriptionOnly" do not require all retained messages to be processed. It can be cancelled at an earlier stage.