### PR TITLE
ClientMessageQueueInterceptor continues with subscription processing.

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -4,7 +4,7 @@
 * [Client] An internal exception is no longer caught silently when calling _DisconnectAsync_ to indicate that the disconnect is not clean (BREAKING CHANGE).
 * [Client] MQTTv5 features are now checked and an exception is thrown if they are used when using protocol version 3.1.1 and lower. These checks can be disabled in client options. (BREAKING CHANGE!).
 * [Server] Exposed MQTT v5 sent properties from the affected client in _ClientDisconnectedAsync_ event.
-* [Server] Fixed wrong client ID passed to _InterceptingUnsubscriptionEventArgs_ (#1631, thanks to @ghord). 
+* [Server] Fixed wrong client ID passed to _InterceptingUnsubscriptionEventArgs_ (#1631, thanks to @ghord).
 * [Server] Exposed socket settings for TCP keep alive in TCP options (#1544).
 * [Server] Exposed server session items at server level and allow custom session items for injected application messages (#1638).
 * [Server] Improved performance for retained message handling when subscribing using "DoNotSendOnSubscribe" or "SendAtSubscribeIfNewSubscriptionOnly" (#1661, thanks to @Int32Overflow).
@@ -12,3 +12,4 @@
 * [Server] Added a new API method which allows reading a single retained message without the need to processing the entire set of retained messages (#1659).
 * [Server] Added a new event (InterceptingClientEnqueueAsync) which allows intercepting when an application message is enqueued for a client (#1648).
 * [Server] Fixed race condition when handling connections which leads to stopped message transfers (#1677, thanks to @RazvanEmilR).
+* [Server] Fixed not delivered packets to other sessions if the _InterceptingClientEnqueueEvent_ is used and accepting the packet is denied (#1685, thanks to @RossHNPC).

--- a/Source/MQTTnet.Tests/Server/Publishing_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Publishing_Tests.cs
@@ -105,5 +105,42 @@ namespace MQTTnet.Tests.Server
                 receivedMessages.AssertReceivedCountEquals(1);
             }
         }
+
+        [TestMethod]
+        public async Task Intercept_Client_Enqueue_Multiple_Clients_Subscribed_Messages_Are_Filtered()
+        {
+            using (var testEnvironment = CreateTestEnvironment())
+            {
+                var server = await testEnvironment.StartServer();
+
+                var sender = await testEnvironment.ConnectClient();
+
+                var receiverOne = await testEnvironment.ConnectClient(o => o.WithClientId("One"));
+                await receiverOne.SubscribeAsync("A");
+                var receivedMessagesOne = testEnvironment.CreateApplicationMessageHandler(receiverOne);
+
+                var receiverTwo = await testEnvironment.ConnectClient(o => o.WithClientId("Two"));
+                await receiverTwo.SubscribeAsync("A");
+                var receivedMessagesTwo = testEnvironment.CreateApplicationMessageHandler(receiverTwo);
+
+                var receiverThree = await testEnvironment.ConnectClient(o => o.WithClientId("Three"));
+                await receiverThree.SubscribeAsync("A");
+                var receivedMessagesThree = testEnvironment.CreateApplicationMessageHandler(receiverThree);
+
+                server.InterceptingClientEnqueueAsync += e =>
+                {
+                    if (e.ReceiverClientId.Contains("Two")) e.AcceptEnqueue = false;
+                    return CompletedTask.Instance;
+                };
+
+                await sender.PublishStringAsync("A", "Payload", MqttQualityOfServiceLevel.AtLeastOnce);
+
+                await LongTestDelay();
+
+                receivedMessagesOne.AssertReceivedCountEquals(1);
+                receivedMessagesTwo.AssertReceivedCountEquals(0);
+                receivedMessagesThree.AssertReceivedCountEquals(1);
+            }
+        }
     }
 }

--- a/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
@@ -207,9 +207,8 @@ namespace MQTTnet.Server
 
                             if (!eventArgs.AcceptEnqueue)
                             {
-                                // There will be no reason string and use properties because in this case the clients will
-                                // not receive a packet at all.
-                                return new DispatchApplicationMessageResult(reasonCode, eventArgs.CloseSenderConnection, null, null);
+                                // Continue checking the other subscriptions
+                                continue;
                             }
                         }
 


### PR DESCRIPTION
@chkr1011 Here is a draft PR for the issue I found earlier with the ClientMessageQueueInterceptor with a unit test added to capture the use case of 3 subscribed Clients and a coarse filter in the handler to exclude one of them from receiving messages.

Unit tests I've ran locally... all pass when ran individually be few not so happy when running all together; consistently Disconnect_Clean and Disconnect_Clean_With_Custom_Reason irrespective of target framework, but when ran on their own will pass.