### PR TITLE
Allow disabling of packet fragmentation

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -3,6 +3,7 @@
 * [Client] Added support for passing MQTT v5 options (User properties etc.) for disconnects.
 * [Client] An internal exception is no longer caught silently when calling _DisconnectAsync_ to indicate that the disconnect is not clean (BREAKING CHANGE).
 * [Client] MQTTv5 features are now checked and an exception is thrown if they are used when using protocol version 3.1.1 and lower. These checks can be disabled in client options. (BREAKING CHANGE!).
+* [Client] Added support for disabling packet fragmentation (required for i.e. AWS, #1690, thanks to @logicaloud).
 * [Server] Exposed MQTT v5 sent properties from the affected client in _ClientDisconnectedAsync_ event.
 * [Server] Fixed wrong client ID passed to _InterceptingUnsubscriptionEventArgs_ (#1631, thanks to @ghord). 
 * [Server] Exposed socket settings for TCP keep alive in TCP options (#1544).

--- a/Samples/Client/Client_Connection_Samples.cs
+++ b/Samples/Client/Client_Connection_Samples.cs
@@ -70,6 +70,28 @@ public static class Client_Connection_Samples
             await mqttClient.DisconnectAsync(mqttClientDisconnectOptions, CancellationToken.None);
         }
     }
+    
+    public static async Task Connect_With_Amazon_AWS()
+    {
+        /*
+         * This sample creates a simple MQTT client and connects to an Amazon Web Services broker.
+         *
+         * The broker requires special settings which are set here.
+         */
+
+        var mqttFactory = new MqttFactory();
+
+        using (var mqttClient = mqttFactory.CreateMqttClient())
+        {
+            var mqttClientOptions = new MqttClientOptionsBuilder().WithTcpServer("amazon.web.services.broker").WithAmazonWebServicesCompatibility().Build();
+            
+            await mqttClient.ConnectAsync(mqttClientOptions, CancellationToken.None);
+
+            Console.WriteLine("The MQTT client is connected.");
+
+            await mqttClient.DisconnectAsync();
+        }
+    }
 
     public static async Task Connect_Client_Timeout()
     {

--- a/Samples/Client/Client_Connection_Samples.cs
+++ b/Samples/Client/Client_Connection_Samples.cs
@@ -83,7 +83,11 @@ public static class Client_Connection_Samples
 
         using (var mqttClient = mqttFactory.CreateMqttClient())
         {
-            var mqttClientOptions = new MqttClientOptionsBuilder().WithTcpServer("amazon.web.services.broker").WithAmazonWebServicesCompatibility().Build();
+            var mqttClientOptions = new MqttClientOptionsBuilder()
+                .WithTcpServer("amazon.web.services.broker")
+                // Disabling packet fragmentation is very important!  
+                .WithoutPacketFragmentation()
+                .Build();
             
             await mqttClient.ConnectAsync(mqttClientOptions, CancellationToken.None);
 

--- a/Source/MQTTnet.AspnetCore/MqttWebSocketServerAdapter.cs
+++ b/Source/MQTTnet.AspnetCore/MqttWebSocketServerAdapter.cs
@@ -48,7 +48,7 @@ namespace MQTTnet.AspNetCore
                     var formatter = new MqttPacketFormatterAdapter(new MqttBufferWriter(4096, 65535));
                     var channel = new MqttWebSocketChannel(webSocket, endpoint, isSecureConnection, clientCertificate);
 
-                    using (var channelAdapter = new MqttChannelAdapter(channel, formatter, null, _logger))
+                    using (var channelAdapter = new MqttChannelAdapter(channel, formatter, _logger))
                     {
                         await clientHandler(channelAdapter).ConfigureAwait(false);
                     }

--- a/Source/MQTTnet.Benchmarks/ChannelAdapterBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/ChannelAdapterBenchmark.cs
@@ -73,7 +73,7 @@ namespace MQTTnet.Benchmarks
 
             var channel = new MemoryMqttChannel(_stream);
 
-            _channelAdapter = new MqttChannelAdapter(channel, serializer, null, new MqttNetEventLogger());
+            _channelAdapter = new MqttChannelAdapter(channel, serializer, new MqttNetEventLogger());
         }
 
         static byte[] Join(params ArraySegment<byte>[] chunks)

--- a/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
@@ -54,7 +54,7 @@ namespace MQTTnet.Benchmarks
         public void Deserialize_10000_Messages()
         {
             var channel = new BenchmarkMqttChannel(_serializedPacket);
-            var reader = new MqttChannelAdapter(channel, new MqttPacketFormatterAdapter(new MqttBufferWriter(4096, 65535)), null, new MqttNetEventLogger());
+            var reader = new MqttChannelAdapter(channel, new MqttPacketFormatterAdapter(new MqttBufferWriter(4096, 65535)), new MqttNetEventLogger());
 
             for (var i = 0; i < 10000; i++)
             {

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientOptions.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClientOptions.cs
@@ -24,7 +24,7 @@ namespace MQTTnet.Extensions.ManagedClient
 
         /// <summary>
         /// Defines the maximum amount of topic filters which will be sent in a SUBSCRIBE/UNSUBSCRIBE packet.
-        /// Amazon AWS limits this number to 8. The default is int.MaxValue.
+        /// Amazon Web Services (AWS) limits this number to 8. The default is int.MaxValue.
         /// </summary>
         public int MaxTopicFiltersInSubscribeUnsubscribePackets { get; set; } = int.MaxValue;
     }

--- a/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttClientAdapterFactory.cs
+++ b/Source/MQTTnet.Extensions.WebSocket4Net/WebSocket4NetMqttClientAdapterFactory.cs
@@ -27,8 +27,10 @@ namespace MQTTnet.Extensions.WebSocket4Net
                     return new MqttChannelAdapter(
                         new MqttTcpChannel(options),
                         new MqttPacketFormatterAdapter(options.ProtocolVersion, new MqttBufferWriter(options.WriterBufferSize, options.WriterBufferSizeMax)),
-                        packetInspector,
-                        logger);
+                        logger)
+                    {
+                        PacketInspector = packetInspector
+                    };
                 }
 
                 case MqttClientWebSocketOptions webSocketOptions:
@@ -36,8 +38,10 @@ namespace MQTTnet.Extensions.WebSocket4Net
                     return new MqttChannelAdapter(
                         new WebSocket4NetMqttChannel(options, webSocketOptions),
                         new MqttPacketFormatterAdapter(options.ProtocolVersion, new MqttBufferWriter(options.WriterBufferSize, options.WriterBufferSizeMax)),
-                        packetInspector,
-                        logger);
+                        logger)
+                    {
+                        PacketInspector = packetInspector
+                    };
                 }
 
                 default:

--- a/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V3_Binary_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V3_Binary_Tests.cs
@@ -566,7 +566,6 @@ namespace MQTTnet.Tests.Formatter
                     using (var adapter = new MqttChannelAdapter(
                                channel,
                                new MqttPacketFormatterAdapter(protocolVersion, new MqttBufferWriter(4096, 65535)),
-                               null,
                                new MqttNetEventLogger()))
                     {
                         var receivedPacket = adapter.ReceivePacketAsync(CancellationToken.None).GetAwaiter().GetResult();
@@ -582,17 +581,10 @@ namespace MQTTnet.Tests.Formatter
         MqttProtocolVersion DeserializeAndDetectVersion(MqttPacketFormatterAdapter packetFormatterAdapter, byte[] buffer)
         {
             var channel = new MemoryMqttChannel(buffer);
-            var adapter = new MqttChannelAdapter(channel, packetFormatterAdapter, null, new MqttNetEventLogger());
+            var adapter = new MqttChannelAdapter(channel, packetFormatterAdapter, new MqttNetEventLogger());
 
             adapter.ReceivePacketAsync(CancellationToken.None).GetAwaiter().GetResult();
             return packetFormatterAdapter.ProtocolVersion;
-        }
-
-        MqttBufferReader ReaderFactory(byte[] data)
-        {
-            var reader = new MqttBufferReader();
-            reader.SetBuffer(data, 0, data.Length);
-            return reader;
         }
 
         TPacket Roundtrip<TPacket>(TPacket packet, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311, MqttBufferWriter bufferWriter = null) where TPacket : MqttPacket
@@ -603,7 +595,7 @@ namespace MQTTnet.Tests.Formatter
 
             using (var channel = new MemoryMqttChannel(buffer.Join().ToArray()))
             {
-                var adapter = new MqttChannelAdapter(channel, new MqttPacketFormatterAdapter(protocolVersion, new MqttBufferWriter(4096, 65535)), null, new MqttNetEventLogger());
+                var adapter = new MqttChannelAdapter(channel, new MqttPacketFormatterAdapter(protocolVersion, new MqttBufferWriter(4096, 65535)), new MqttNetEventLogger());
                 return (TPacket)adapter.ReceivePacketAsync(CancellationToken.None).GetAwaiter().GetResult();
             }
         }

--- a/Source/MQTTnet.Tests/MqttPacketSerializationHelper.cs
+++ b/Source/MQTTnet.Tests/MqttPacketSerializationHelper.cs
@@ -31,7 +31,7 @@ namespace MQTTnet.Tests
             {
                 var formatterAdapter = new MqttPacketFormatterAdapter(_protocolVersion, new MqttBufferWriter(4096, 65535));
 
-                var adapter = new MqttChannelAdapter(channel, formatterAdapter, null, MqttNetNullLogger.Instance);
+                var adapter = new MqttChannelAdapter(channel, formatterAdapter, MqttNetNullLogger.Instance);
                 return adapter.ReceivePacketAsync(CancellationToken.None).GetAwaiter().GetResult();
             }
         }

--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -62,8 +62,8 @@ namespace MQTTnet.Adapter
         public MqttPacketFormatterAdapter PacketFormatterAdapter { get; }
 
         public MqttPacketInspector PacketInspector { get; set; }
-        
-        public bool AvoidPacketFragmentation { get; set; }
+
+        public bool AllowPacketFragmentation { get; set; } = true;
 
         public async Task ConnectAsync(CancellationToken cancellationToken)
         {
@@ -205,7 +205,7 @@ namespace MQTTnet.Adapter
 
                     _logger.Verbose("TX ({0} bytes) >>> {1}", packetBuffer.Length, packet);
                     
-                    if (packetBuffer.Payload.Count == 0 || AvoidPacketFragmentation)
+                    if (packetBuffer.Payload.Count == 0 || !AllowPacketFragmentation)
                     {
                         await _channel.WriteAsync(packetBuffer.Join(), true, cancellationToken).ConfigureAwait(false);
                     }

--- a/Source/MQTTnet/Client/Options/MqttClientOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptions.cs
@@ -24,6 +24,14 @@ namespace MQTTnet.Client
         /// </summary>
         public string AuthenticationMethod { get; set; }
 
+        /// <summary>
+        ///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
+        ///     or WebSocket frames etc. Unfortunately not all brokers (like Amazon Web Services (AWS)) do not support this and
+        ///     will close the connection when receiving such packets. If such a service is used this flag must
+        ///     be set to _true_.
+        /// </summary>
+        public bool AvoidPacketFragmentation { get; set; }
+
         public IMqttClientChannelOptions ChannelOptions { get; set; }
 
         /// <summary>

--- a/Source/MQTTnet/Client/Options/MqttClientOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptions.cs
@@ -26,7 +26,7 @@ namespace MQTTnet.Client
 
         /// <summary>
         ///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
-        ///     or WebSocket frames etc. Unfortunately not all brokers (like Amazon Web Services (AWS)) do not support this and
+        ///     or WebSocket frames etc. Unfortunately not all brokers (like Amazon Web Services (AWS)) do support this feature and
         ///     will close the connection when receiving such packets. If such a service is used this flag must
         ///     be set to _true_.
         /// </summary>

--- a/Source/MQTTnet/Client/Options/MqttClientOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptions.cs
@@ -28,9 +28,9 @@ namespace MQTTnet.Client
         ///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
         ///     or WebSocket frames etc. Unfortunately not all brokers (like Amazon Web Services (AWS)) do support this feature and
         ///     will close the connection when receiving such packets. If such a service is used this flag must
-        ///     be set to _true_.
+        ///     be set to _false_.
         /// </summary>
-        public bool AvoidPacketFragmentation { get; set; }
+        public bool AllowPacketFragmentation { get; set; } = true;
 
         public IMqttClientChannelOptions ChannelOptions { get; set; }
 

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -87,7 +87,7 @@ namespace MQTTnet.Client
         /// </summary>
         public MqttClientOptionsBuilder WithoutPacketFragmentation()
         {
-            _options.AllowPacketFragmentation = true;
+            _options.AllowPacketFragmentation = false;
             return this;
         }
 

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -79,10 +79,15 @@ namespace MQTTnet.Client
             return _options;
         }
 
-        public MqttClientOptionsBuilder WithAmazonWebServicesCompatibility()
+        /// <summary>
+        ///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
+        ///     or WebSocket frames etc. Unfortunately not all brokers (like Amazon Web Services (AWS)) do support this feature and
+        ///     will close the connection when receiving such packets. If such a service is used this flag must
+        ///     be set to _true_.
+        /// </summary>
+        public MqttClientOptionsBuilder WithoutPacketFragmentation()
         {
-            // Fragmented WebSocket messages are not supported by AWS.
-            _options.AvoidPacketFragmentation = true;
+            _options.AllowPacketFragmentation = true;
             return this;
         }
 

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -75,8 +75,15 @@ namespace MQTTnet.Client
             _options.ChannelOptions = (IMqttClientChannelOptions)_tcpOptions ?? _webSocketOptions;
 
             MqttClientOptionsValidator.ThrowIfNotSupported(_options);
-            
+
             return _options;
+        }
+
+        public MqttClientOptionsBuilder WithAmazonWebServicesCompatibility()
+        {
+            // Fragmented WebSocket messages are not supported by AWS.
+            _options.AvoidPacketFragmentation = true;
+            return this;
         }
 
         public MqttClientOptionsBuilder WithAuthentication(string method, byte[] data)
@@ -266,7 +273,7 @@ namespace MQTTnet.Client
 
             return this;
         }
-        
+
         public MqttClientOptionsBuilder WithTcpServer(Action<MqttClientTcpOptions> optionsBuilder)
         {
             if (optionsBuilder == null)
@@ -373,6 +380,18 @@ namespace MQTTnet.Client
             return this;
         }
 
+        public MqttClientOptionsBuilder WithWillContentType(string willContentType)
+        {
+            _options.WillContentType = willContentType;
+            return this;
+        }
+
+        public MqttClientOptionsBuilder WithWillCorrelationData(byte[] willCorrelationData)
+        {
+            _options.WillCorrelationData = willCorrelationData;
+            return this;
+        }
+
         public MqttClientOptionsBuilder WithWillDelayInterval(uint willDelayInterval)
         {
             _options.WillDelayInterval = willDelayInterval;
@@ -384,15 +403,21 @@ namespace MQTTnet.Client
             _options.WillPayload = willPayload;
             return this;
         }
-        
+
         public MqttClientOptionsBuilder WithWillPayload(string willPayload)
         {
             if (string.IsNullOrEmpty(willPayload))
             {
                 return WithWillPayload((byte[])null);
             }
-            
+
             _options.WillPayload = Encoding.UTF8.GetBytes(willPayload);
+            return this;
+        }
+
+        public MqttClientOptionsBuilder WithWillPayloadFormatIndicator(MqttPayloadFormatIndicator willPayloadFormatIndicator)
+        {
+            _options.WillPayloadFormatIndicator = willPayloadFormatIndicator;
             return this;
         }
 
@@ -402,9 +427,9 @@ namespace MQTTnet.Client
             return this;
         }
 
-        public MqttClientOptionsBuilder WithWillTopic(string willTopic)
+        public MqttClientOptionsBuilder WithWillResponseTopic(string willResponseTopic)
         {
-            _options.WillTopic = willTopic;
+            _options.WillResponseTopic = willResponseTopic;
             return this;
         }
 
@@ -413,38 +438,20 @@ namespace MQTTnet.Client
             _options.WillRetain = willRetain;
             return this;
         }
-        
-        public MqttClientOptionsBuilder WithWillContentType(string willContentType)
+
+        public MqttClientOptionsBuilder WithWillTopic(string willTopic)
         {
-            _options.WillContentType = willContentType;
+            _options.WillTopic = willTopic;
             return this;
         }
-        
-        public MqttClientOptionsBuilder WithWillCorrelationData(byte[] willCorrelationData)
-        {
-            _options.WillCorrelationData = willCorrelationData;
-            return this;
-        }
-        
-        public MqttClientOptionsBuilder WithWillResponseTopic(string willResponseTopic)
-        {
-            _options.WillResponseTopic = willResponseTopic;
-            return this;
-        }
-        
-        public MqttClientOptionsBuilder WithWillPayloadFormatIndicator(MqttPayloadFormatIndicator willPayloadFormatIndicator)
-        {
-            _options.WillPayloadFormatIndicator = willPayloadFormatIndicator;
-            return this;
-        }
-        
+
         public MqttClientOptionsBuilder WithWillUserProperty(string name, string value)
         {
             if (_options.WillUserProperties == null)
             {
                 _options.WillUserProperties = new List<MqttUserProperty>();
             }
-            
+
             _options.WillUserProperties.Add(new MqttUserProperty(name, value));
             return this;
         }

--- a/Source/MQTTnet/Implementations/MqttClientAdapterFactory.cs
+++ b/Source/MQTTnet/Implementations/MqttClientAdapterFactory.cs
@@ -43,7 +43,7 @@ namespace MQTTnet.Implementations
 
             return new MqttChannelAdapter(channel, packetFormatterAdapter, logger)
             {
-                AvoidPacketFragmentation = options.AvoidPacketFragmentation,
+                AllowPacketFragmentation = options.AllowPacketFragmentation,
                 PacketInspector = packetInspector
             };
         }

--- a/Source/MQTTnet/Implementations/MqttClientAdapterFactory.cs
+++ b/Source/MQTTnet/Implementations/MqttClientAdapterFactory.cs
@@ -40,7 +40,12 @@ namespace MQTTnet.Implementations
 
             var bufferWriter = new MqttBufferWriter(options.WriterBufferSize, options.WriterBufferSizeMax);
             var packetFormatterAdapter = new MqttPacketFormatterAdapter(options.ProtocolVersion, bufferWriter);
-            return new MqttChannelAdapter(channel, packetFormatterAdapter, packetInspector, logger);
+
+            return new MqttChannelAdapter(channel, packetFormatterAdapter, logger)
+            {
+                AvoidPacketFragmentation = options.AvoidPacketFragmentation,
+                PacketInspector = packetInspector
+            };
         }
     }
 }

--- a/Source/MQTTnet/Implementations/MqttTcpServerAdapter.Uwp.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerAdapter.Uwp.cs
@@ -95,7 +95,7 @@ namespace MQTTnet.Implementations
                     var packetFormatterAdapter = new MqttPacketFormatterAdapter(bufferWriter);
                     var tcpChannel = new MqttTcpChannel(args.Socket, clientCertificate, _options);
 
-                    using (var clientAdapter = new MqttChannelAdapter(tcpChannel, packetFormatterAdapter, null, _rootLogger))
+                    using (var clientAdapter = new MqttChannelAdapter(tcpChannel, packetFormatterAdapter, _rootLogger))
                     {
                         await clientHandler(clientAdapter).ConfigureAwait(false);
                     }

--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -229,7 +229,7 @@ namespace MQTTnet.Implementations
                     var bufferWriter = new MqttBufferWriter(_serverOptions.WriterBufferSize, _serverOptions.WriterBufferSizeMax);
                     var packetFormatterAdapter = new MqttPacketFormatterAdapter(bufferWriter);
                     
-                    using (var clientAdapter = new MqttChannelAdapter(tcpChannel, packetFormatterAdapter, null, _rootLogger))
+                    using (var clientAdapter = new MqttChannelAdapter(tcpChannel, packetFormatterAdapter, _rootLogger))
                     {
                         await clientHandler(clientAdapter).ConfigureAwait(false);
                     }


### PR DESCRIPTION
This PR adds support for disabling the MQTT packet fragmentation into several TCP packets or WebSocket frames. This is required to allow connections with several brokers.