### PR TITLE
Rename InspectPackage method

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -5,6 +5,7 @@
 * [Client] MQTTv5 features are now checked and an exception is thrown if they are used when using protocol version 3.1.1 and lower. These checks can be disabled in client options. (BREAKING CHANGE!).
 * [Client] Added support for disabling packet fragmentation (required for i.e. AWS, #1690, thanks to @logicaloud).
 * [Client] Added new overloads for options builder.
+* [Client] Renamed _InspectPackage_ to _InspectPacketAsync_ (BREAKING CHANGE).
 * [ManagedClient] Exposed added and removed topics in _ManagedProcessFailedEventArgs_ (#1678, thanks to @scottbrogden-iheartmedia).
 * [Server] Exposed MQTT v5 sent properties from the affected client in _ClientDisconnectedAsync_ event.
 * [Server] Fixed wrong client ID passed to _InterceptingUnsubscriptionEventArgs_ (#1631, thanks to @ghord).

--- a/Samples/Diagnostics/PackageInspection_Samples.cs
+++ b/Samples/Diagnostics/PackageInspection_Samples.cs
@@ -26,7 +26,7 @@ public static class PackageInspection_Samples
                 .WithTcpServer("broker.hivemq.com")
                 .Build();
             
-            mqttClient.InspectPackage += OnInspectPackage;
+            mqttClient.InspectPacketAsync += OnInspectPacket;
             
             await mqttClient.ConnectAsync(mqttClientOptions, CancellationToken.None);
             
@@ -39,7 +39,7 @@ public static class PackageInspection_Samples
         }
     }
 
-    static Task OnInspectPackage(InspectMqttPacketEventArgs eventArgs)
+    static Task OnInspectPacket(InspectMqttPacketEventArgs eventArgs)
     {
         if (eventArgs.Direction == MqttPacketFlowDirection.Inbound)
         {

--- a/Source/MQTTnet.Tests/Diagnostics/PacketInspection_Tests.cs
+++ b/Source/MQTTnet.Tests/Diagnostics/PacketInspection_Tests.cs
@@ -30,7 +30,7 @@ namespace MQTTnet.Tests.Diagnostics
 
                     var packets = new List<string>();
                     
-                    mqttClient.InspectPackage += eventArgs =>
+                    mqttClient.InspectPacketAsync += eventArgs =>
                     {
                         packets.Add(eventArgs.Direction + ":" + Convert.ToBase64String(eventArgs.Buffer));
                         return CompletedTask.Instance;

--- a/Source/MQTTnet.Tests/Server/General.cs
+++ b/Source/MQTTnet.Tests/Server/General.cs
@@ -954,7 +954,7 @@ namespace MQTTnet.Tests.Server
 
                 var client = testEnvironment.CreateClient();
 
-                client.InspectPackage += e =>
+                client.InspectPacketAsync += e =>
                 {
                     if (e.Buffer.Length > 0)
                     {

--- a/Source/MQTTnet/Client/IMqttClient.cs
+++ b/Source/MQTTnet/Client/IMqttClient.cs
@@ -15,7 +15,7 @@ namespace MQTTnet.Client
 
         event Func<MqttClientDisconnectedEventArgs, Task> DisconnectedAsync;
 
-        event Func<InspectMqttPacketEventArgs, Task> InspectPackage;
+        event Func<InspectMqttPacketEventArgs, Task> InspectPacketAsync;
 
         bool IsConnected { get; }
 

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -87,7 +87,7 @@ namespace MQTTnet.Client
             remove => _disconnectedEvent.RemoveHandler(value);
         }
 
-        public event Func<InspectMqttPacketEventArgs, Task> InspectPackage
+        public event Func<InspectMqttPacketEventArgs, Task> InspectPacketAsync
         {
             add => _inspectPacketEvent.AddHandler(value);
             remove => _inspectPacketEvent.RemoveHandler(value);

--- a/Source/MQTTnet/LowLevelClient/ILowLevelMqttClient.cs
+++ b/Source/MQTTnet/LowLevelClient/ILowLevelMqttClient.cs
@@ -9,7 +9,7 @@ namespace MQTTnet.LowLevelClient
 {
     public interface ILowLevelMqttClient : IDisposable
     {
-        event Func<InspectMqttPacketEventArgs, Task> InspectPackage;
+        event Func<InspectMqttPacketEventArgs, Task> InspectPacketAsync;
         
         bool IsConnected { get; }
         


### PR DESCRIPTION
This pull requests changes the name of the _InspectPackage_ method in order to align the name with other namings in the project.