### PR TITLE
Add new overloads for packet payload and will payload

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,2 +1,3 @@
 * [Core] Add validation of maximum string lengths (#1718).
+* [Client] Added overloads for setting packet payload and will payload (#1720).
 * [Server] Improved performance by changing internal locking strategy for subscriptions (#1716, thanks to @zeheng).

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -418,6 +418,18 @@ namespace MQTTnet.Client
         public MqttClientOptionsBuilder WithWillPayload(byte[] willPayload)
         {
             _options.WillPayload = willPayload;
+            return this;
+        }
+
+        public MqttClientOptionsBuilder WithWillPayload(ArraySegment<byte> willPayload)
+        {
+            if (willPayload.Count == 0)
+            {
+                _options.WillPayload = null;
+                return this;
+            }
+
+            _options.WillPayload = willPayload.ToArray();
             return this;
         }
 

--- a/Source/MQTTnet/Client/Publishing/MqttClientPublishResult.cs
+++ b/Source/MQTTnet/Client/Publishing/MqttClientPublishResult.cs
@@ -34,7 +34,7 @@ namespace MQTTnet.Client
         ///     Gets or sets the reason code.
         ///     <remarks>MQTT 5.0.0+ feature.</remarks>
         /// </summary>
-        public MqttClientPublishReasonCode ReasonCode { get; } = MqttClientPublishReasonCode.Success;
+        public MqttClientPublishReasonCode ReasonCode { get; }
 
         /// <summary>
         ///     Gets or sets the reason string.

--- a/Source/MQTTnet/MqttApplicationMessageBuilder.cs
+++ b/Source/MQTTnet/MqttApplicationMessageBuilder.cs
@@ -2,16 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using MQTTnet.Exceptions;
-using MQTTnet.Internal;
-using MQTTnet.Packets;
-using MQTTnet.Protocol;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
+using MQTTnet.Exceptions;
+using MQTTnet.Internal;
+using MQTTnet.Packets;
+using MQTTnet.Protocol;
 
 namespace MQTTnet
 {
@@ -89,9 +88,13 @@ namespace MQTTnet
 
         public MqttApplicationMessageBuilder WithPayload(byte[] payload)
         {
-            _payloadSegment = payload == null || payload.Length == 0
-                ? EmptyBuffer.ArraySegment
-                : new ArraySegment<byte>(payload);
+            _payloadSegment = payload == null || payload.Length == 0 ? EmptyBuffer.ArraySegment : new ArraySegment<byte>(payload);
+            return this;
+        }
+
+        public MqttApplicationMessageBuilder WithPayload(ArraySegment<byte> payloadSegment)
+        {
+            _payloadSegment = payloadSegment;
             return this;
         }
 
@@ -123,9 +126,7 @@ namespace MQTTnet
 
         public MqttApplicationMessageBuilder WithPayload(Stream payload)
         {
-            return payload == null
-                ? WithPayload(default(byte[]))
-                : WithPayload(payload, payload.Length - payload.Position);
+            return payload == null ? WithPayload(default(byte[])) : WithPayload(payload, payload.Length - payload.Position);
         }
 
         public MqttApplicationMessageBuilder WithPayload(Stream payload, long length)

--- a/Source/MQTTnet/MqttApplicationMessageBuilder.cs
+++ b/Source/MQTTnet/MqttApplicationMessageBuilder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using MQTTnet.Exceptions;
 using MQTTnet.Internal;
@@ -19,9 +20,9 @@ namespace MQTTnet
         string _contentType;
         byte[] _correlationData;
         uint _messageExpiryInterval;
-        ArraySegment<byte> _payloadSegment;
 
         MqttPayloadFormatIndicator _payloadFormatIndicator;
+        ArraySegment<byte> _payloadSegment;
         MqttQualityOfServiceLevel _qualityOfServiceLevel = MqttQualityOfServiceLevel.AtMostOnce;
         string _responseTopic;
         bool _retain;
@@ -98,12 +99,6 @@ namespace MQTTnet
             return this;
         }
 
-        public MqttApplicationMessageBuilder WithPayloadSegment(ArraySegment<byte> payloadSegment)
-        {
-            _payloadSegment = payloadSegment;
-            return this;
-        }
-
         public MqttApplicationMessageBuilder WithPayload(IEnumerable<byte> payload)
         {
             if (payload == null)
@@ -163,16 +158,6 @@ namespace MQTTnet
             return WithPayload(payloadBuffer);
         }
 
-
-#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1
-        public MqttApplicationMessageBuilder WithPayloadSegment(ReadOnlyMemory<byte> payloadSegment)
-        {
-            return MemoryMarshal.TryGetArray(payloadSegment, out var segment)
-                ? WithPayloadSegment(segment)
-                : WithPayload(payloadSegment.ToArray());
-        }
-#endif
-
         /// <summary>
         ///     Adds the payload format indicator to the message.
         ///     <remarks>MQTT 5.0.0+ feature.</remarks>
@@ -182,6 +167,20 @@ namespace MQTTnet
             _payloadFormatIndicator = payloadFormatIndicator;
             return this;
         }
+
+        public MqttApplicationMessageBuilder WithPayloadSegment(ArraySegment<byte> payloadSegment)
+        {
+            _payloadSegment = payloadSegment;
+            return this;
+        }
+
+
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1
+        public MqttApplicationMessageBuilder WithPayloadSegment(ReadOnlyMemory<byte> payloadSegment)
+        {
+            return MemoryMarshal.TryGetArray(payloadSegment, out var segment) ? WithPayloadSegment(segment) : WithPayload(payloadSegment.ToArray());
+        }
+#endif
 
         /// <summary>
         ///     The quality of service level.


### PR DESCRIPTION
This PR adds new overloads for several builders in order to support ArraySegments without conversion overhead.