### PR TITLE
UseDefaultCredentials options for WebSockets proxy configuration.

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,4 +1,5 @@
 * [Core] Add validation of maximum string lengths (#1718).
 * [Client] Added overloads for setting packet payload and will payload (#1720).
-* [Client] The proper connect result is now exposed in the _Disconnected_ event when authentication fails (#1139). 
+* [Client] The proper connect result is now exposed in the _Disconnected_ event when authentication fails (#1139).
+* [Client] Exposed _UseDefaultCredentials_ and more for Web Socket options and proxy options (#1734, thanks to @impworks).
 * [Server] Improved performance by changing internal locking strategy for subscriptions (#1716, thanks to @zeheng).

--- a/Source/MQTTnet/Client/Options/MqttClientWebSocketOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientWebSocketOptions.cs
@@ -2,15 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.WebSockets;
 
 namespace MQTTnet.Client
 {
     public sealed class MqttClientWebSocketOptions : IMqttClientChannelOptions
     {
         public CookieContainer CookieContainer { get; set; }
-        
+
+        public ICredentials Credentials { get; set; }
+
         public MqttClientWebSocketProxyOptions ProxyOptions { get; set; }
 
         public IDictionary<string, string> RequestHeaders { get; set; }
@@ -18,12 +22,26 @@ namespace MQTTnet.Client
         public ICollection<string> SubProtocols { get; set; } = new List<string> { "mqtt" };
 
         public MqttClientTlsOptions TlsOptions { get; set; } = new MqttClientTlsOptions();
-        
+
         public string Uri { get; set; }
 
         public override string ToString()
         {
             return Uri;
         }
+
+#if !NETSTANDARD1_3
+        /// <summary>
+        ///     Gets or sets the keep alive interval for the Web Socket connection.
+        ///     This is not related to the keep alive interval for the MQTT protocol.
+        /// </summary>
+        public TimeSpan KeepAliveInterval { get; set; } = WebSocket.DefaultKeepAliveInterval;
+
+        /// <summary>
+        ///     Gets or sets whether the default (system) credentials should be used when connecting via Web Socket connection.
+        ///     This is not related to the credentials which are used for the MQTT protocol.
+        /// </summary>
+        public bool UseDefaultCredentials { get; set; }
+#endif
     }
 }

--- a/Source/MQTTnet/Client/Options/MqttClientWebSocketProxyOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientWebSocketProxyOptions.cs
@@ -16,6 +16,8 @@ namespace MQTTnet.Client
 
         public bool BypassOnLocal { get; set; }
 
+        public bool UseDefaultCredentials { get; set; }
+
         public string[] BypassList { get; set; }
     }
 }

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -162,7 +162,10 @@ namespace MQTTnet.Implementations
                 return new WebProxy(proxyUri, _options.ProxyOptions.BypassOnLocal, _options.ProxyOptions.BypassList, credentials);
             }
 
-            return new WebProxy(proxyUri, _options.ProxyOptions.BypassOnLocal, _options.ProxyOptions.BypassList);
+            return new WebProxy(proxyUri, _options.ProxyOptions.BypassOnLocal, _options.ProxyOptions.BypassList)
+            {
+                UseDefaultCredentials = _options.ProxyOptions.UseDefaultCredentials
+            };
 #endif
         }
 


### PR DESCRIPTION
This PR adds an option to pass `UseDefaultCredentials` option to the `WebProxy` used by WebSockets implementation.