### PR TITLE
Resolve ConvertPayloadToString resulting in ArgumentNullException

### DIFF
--- a/Source/MQTTnet/MqttApplicationMessageExtensions.cs
+++ b/Source/MQTTnet/MqttApplicationMessageExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Text;
+using MQTTnet.Internal;
 
 namespace MQTTnet
 {
@@ -14,6 +15,11 @@ namespace MQTTnet
             if (applicationMessage == null)
             {
                 throw new ArgumentNullException(nameof(applicationMessage));
+            }
+
+            if(applicationMessage.PayloadSegment == EmptyBuffer.ArraySegment)
+            {
+                return null;
             }
 
             var payloadSegment = applicationMessage.PayloadSegment;


### PR DESCRIPTION

MqttApplicationMessageExtensions.ConvertPayloadToString results in ArgumentNullException which is a breaking change:

In the past where the payload was null the return value was null;

Currently:

https://github.com/dotnet/MQTTnet/blob/2cdad6622ab2e82796653a6d5a7adadc5f278217/Source/MQTTnet/MqttApplicationMessageExtensions.cs#L12-L21

In the past:

https://github.com/dotnet/MQTTnet/blob/ba575371088b3a9a21f2391642a9917343dccdc9/Source/MQTTnet/MqttApplicationMessageExtensions.cs#L14-L26


This fix returns null is the payload structure is empty. The problem here is that its a structure so it no longer can be null. In the past a null payload return null and a 0 byte array returned string.Empty

I chose null as that seems the safest of the options as if the processor cannot deal with null it would result in a NullReferenceException similar as the current implementation resulting in a ArgumentNullException
