### PR TITLE
1742 some bug in mqttclientconnectionvalidatorhandle

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -7,3 +7,4 @@
 * [Client] Exposed more TLS options (#1729).
 * [Client] Fixed wrong return code conversion (#1729).
 * [Server] Improved performance by changing internal locking strategy for subscriptions (#1716, thanks to @zeheng).
+* [Server] Fixed exceptions when clients are connecting and disconnecting very fast while accessing the client status for connection validation (#1742).

--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -200,7 +200,7 @@ namespace MQTTnet.Server
         {
             ThrowIfNotStarted();
 
-            return _clientSessionsManager.GetClientStatusesAsync();
+            return _clientSessionsManager.GetClientsStatus();
         }
 
         public Task<IList<MqttApplicationMessage>> GetRetainedMessagesAsync()
@@ -226,7 +226,7 @@ namespace MQTTnet.Server
         {
             ThrowIfNotStarted();
 
-            return _clientSessionsManager.GetSessionStatusAsync();
+            return _clientSessionsManager.GetSessionsStatus();
         }
 
         public Task InjectApplicationMessage(InjectedMqttApplicationMessage injectedApplicationMessage, CancellationToken cancellationToken = default)
@@ -292,7 +292,7 @@ namespace MQTTnet.Server
 
                 _cancellationTokenSource.Cancel(false);
 
-                await _clientSessionsManager.CloseAllConnectionsAsync().ConfigureAwait(false);
+                await _clientSessionsManager.CloseAllConnections().ConfigureAwait(false);
 
                 foreach (var adapter in _adapters)
                 {


### PR DESCRIPTION
This PR adds missing locks so that the client status can be obtained while a lot of clients are connecting and disconnecting.