### PR TITLE
1681 misleading signature of mqttclientconnectasync mqttclientconnectresultcode expected but throws exception

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -6,4 +6,5 @@
 * [Client] Exposed _UseDefaultCredentials_ and more for Web Socket options and proxy options (#1734, thanks to @impworks).
 * [Client] Exposed more TLS options (#1729).
 * [Client] Fixed wrong return code conversion (#1729).
+* [Client] Added an option to avoid throwing an exception when the server returned a proper non success (but valid) response (#1681).
 * [Server] Improved performance by changing internal locking strategy for subscriptions (#1716, thanks to @zeheng).

--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Connection_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Connection_Tests.cs
@@ -191,7 +191,7 @@ namespace MQTTnet.Tests.Clients.MqttClient
                 var response = await client.ConnectAsync(testEnvironment.CreateDefaultClientOptionsBuilder().WithoutThrowOnNonSuccessfulConnectResponse().Build());
 
                 Assert.IsNotNull(response);
-                Assert.AreEqual(MqttConnectReasonCode.QuotaExceeded, response.ResultCode);
+                Assert.AreEqual(MqttClientConnectResultCode.QuotaExceeded, response.ResultCode);
                 Assert.AreEqual(response.UserProperties[0].Name, "Property");
                 Assert.AreEqual(response.UserProperties[0].Value, "Value");
             }

--- a/Source/MQTTnet/Client/Internal/MqttClientResultFactory.cs
+++ b/Source/MQTTnet/Client/Internal/MqttClientResultFactory.cs
@@ -6,6 +6,7 @@ namespace MQTTnet.Client.Internal
 {
     public static class MqttClientResultFactory
     {
+        public static readonly MqttClientConnectResultFactory ConnectResult = new MqttClientConnectResultFactory();
         public static readonly MqttClientPublishResultFactory PublishResult = new MqttClientPublishResultFactory();
         public static readonly MqttClientSubscribeResultFactory SubscribeResult = new MqttClientSubscribeResultFactory();
         public static readonly MqttClientUnsubscribeResultFactory UnsubscribeResult = new MqttClientUnsubscribeResultFactory();

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -511,7 +511,7 @@ namespace MQTTnet.Client
                 _publishPacketReceiverQueue?.Dispose();
                 _publishPacketReceiverQueue = new AsyncQueue<MqttPublishPacket>();
 
-                var connectResult = await Authenticate(Options, effectiveCancellationToken.Token).ConfigureAwait(false);
+                var connectResult = await Authenticate(channelAdapter, Options, effectiveCancellationToken.Token).ConfigureAwait(false);
                 if (connectResult.ResultCode == MqttClientConnectResultCode.Success)
                 {
                     _publishPacketReceiverTask = Task.Run(() => ProcessReceivedPublishPackets(backgroundCancellationToken), backgroundCancellationToken);

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -137,6 +137,12 @@ namespace MQTTnet.Client
                     }
                 }
 
+                if (connectResult.ResultCode != MqttClientConnectResultCode.Success)
+                {
+                    _logger.Warning("Connecting failed: {0}", connectResult.ResultCode);
+                    return connectResult;
+                }
+
                 _lastPacketSentTimestamp = DateTime.UtcNow;
 
                 var keepAliveInterval = Options.KeepAlivePeriod;
@@ -434,8 +440,7 @@ namespace MQTTnet.Client
 
                 if (receivedPacket is MqttConnAckPacket connAckPacket)
                 {
-                    var clientConnectResultFactory = new MqttClientConnectResultFactory();
-                    result = clientConnectResultFactory.Create(connAckPacket, _adapter.PacketFormatterAdapter.ProtocolVersion);
+                    result = MqttClientResultFactory.ConnectResult.Create(connAckPacket, _adapter.PacketFormatterAdapter.ProtocolVersion);
                 }
                 else
                 {
@@ -447,9 +452,18 @@ namespace MQTTnet.Client
                 throw new MqttConnectingFailedException($"Error while authenticating. {exception.Message}", exception, null);
             }
 
-            if (result.ResultCode != MqttClientConnectResultCode.Success)
+            // This is no feature. It is basically a backward compatibility option and should be removed in the future.
+            // The client should not throw any exception if the transport layer connection was successful and the server
+            // did send a proper ACK packet with a non success response.
+            if (options.ThrowOnNonSuccessfulConnectResponse)
             {
-                throw new MqttConnectingFailedException($"Connecting with MQTT server failed ({result.ResultCode}).", null, result);
+                _logger.Warning(
+                    "Client will now throw an _MqttConnectingFailedException_. This is obsolete and will be removed in the future. Consider setting _ThrowOnNonSuccessfulResponseFromServer=False_ in client options.");
+
+                if (result.ResultCode != MqttClientConnectResultCode.Success)
+                {
+                    throw new MqttConnectingFailedException($"Connecting with MQTT server failed ({result.ResultCode}).", null, result);
+                }
             }
 
             _logger.Verbose("Authenticated MQTT connection with server established.");
@@ -498,9 +512,11 @@ namespace MQTTnet.Client
                 _publishPacketReceiverQueue = new AsyncQueue<MqttPublishPacket>();
 
                 var connectResult = await Authenticate(Options, effectiveCancellationToken.Token).ConfigureAwait(false);
-
-                _publishPacketReceiverTask = Task.Run(() => ProcessReceivedPublishPackets(backgroundCancellationToken), backgroundCancellationToken);
-                _packetReceiverTask = Task.Run(() => ReceivePacketsLoop(backgroundCancellationToken), backgroundCancellationToken);
+                if (connectResult.ResultCode == MqttClientConnectResultCode.Success)
+                {
+                    _publishPacketReceiverTask = Task.Run(() => ProcessReceivedPublishPackets(backgroundCancellationToken), backgroundCancellationToken);
+                    _packetReceiverTask = Task.Run(() => ReceivePacketsLoop(backgroundCancellationToken), backgroundCancellationToken);
+                }
 
                 return connectResult;
             }
@@ -754,6 +770,65 @@ namespace MQTTnet.Client
             return packet;
         }
 
+        async Task ReceivePacketsLoop(CancellationToken cancellationToken)
+        {
+            try
+            {
+                _logger.Verbose("Start receiving packets.");
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var packet = await Receive(cancellationToken).ConfigureAwait(false);
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    if (packet == null)
+                    {
+                        await DisconnectInternal(_packetReceiverTask, null, null).ConfigureAwait(false);
+
+                        return;
+                    }
+
+                    await TryProcessReceivedPacket(packet, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception exception)
+            {
+                if (_cleanDisconnectInitiated)
+                {
+                    return;
+                }
+
+                if (exception is AggregateException aggregateException)
+                {
+                    exception = aggregateException.GetBaseException();
+                }
+
+                if (exception is OperationCanceledException)
+                {
+                }
+                else if (exception is MqttCommunicationException)
+                {
+                    _logger.Warning(exception, "Communication error while receiving packets.");
+                }
+                else
+                {
+                    _logger.Error(exception, "Error while receiving packets.");
+                }
+
+                _packetDispatcher.FailAll(exception);
+
+                await DisconnectInternal(_packetReceiverTask, exception, null).ConfigureAwait(false);
+            }
+            finally
+            {
+                _logger.Verbose("Stopped receiving packets.");
+            }
+        }
+
         async Task<TResponsePacket> Request<TResponsePacket>(MqttPacket requestPacket, CancellationToken cancellationToken) where TResponsePacket : MqttPacket
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -917,65 +992,6 @@ namespace MQTTnet.Client
                 _packetDispatcher.FailAll(exception);
 
                 await DisconnectInternal(_packetReceiverTask, exception, null).ConfigureAwait(false);
-            }
-        }
-
-        async Task ReceivePacketsLoop(CancellationToken cancellationToken)
-        {
-            try
-            {
-                _logger.Verbose("Start receiving packets.");
-
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    var packet = await Receive(cancellationToken).ConfigureAwait(false);
-
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        return;
-                    }
-
-                    if (packet == null)
-                    {
-                        await DisconnectInternal(_packetReceiverTask, null, null).ConfigureAwait(false);
-
-                        return;
-                    }
-
-                    await TryProcessReceivedPacket(packet, cancellationToken).ConfigureAwait(false);
-                }
-            }
-            catch (Exception exception)
-            {
-                if (_cleanDisconnectInitiated)
-                {
-                    return;
-                }
-
-                if (exception is AggregateException aggregateException)
-                {
-                    exception = aggregateException.GetBaseException();
-                }
-
-                if (exception is OperationCanceledException)
-                {
-                }
-                else if (exception is MqttCommunicationException)
-                {
-                    _logger.Warning(exception, "Communication error while receiving packets.");
-                }
-                else
-                {
-                    _logger.Error(exception, "Error while receiving packets.");
-                }
-
-                _packetDispatcher.FailAll(exception);
-
-                await DisconnectInternal(_packetReceiverTask, exception, null).ConfigureAwait(false);
-            }
-            finally
-            {
-                _logger.Verbose("Stopped receiving packets.");
             }
         }
 

--- a/Source/MQTTnet/Client/Options/MqttClientOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptions.cs
@@ -13,6 +13,14 @@ namespace MQTTnet.Client
     public sealed class MqttClientOptions
     {
         /// <summary>
+        ///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
+        ///     or WebSocket frames etc. Unfortunately not all brokers (like Amazon Web Services (AWS)) do support this feature and
+        ///     will close the connection when receiving such packets. If such a service is used this flag must
+        ///     be set to _false_.
+        /// </summary>
+        public bool AllowPacketFragmentation { get; set; } = true;
+
+        /// <summary>
         ///     Gets or sets the authentication data.
         ///     <remarks>MQTT 5.0.0+ feature.</remarks>
         /// </summary>
@@ -23,14 +31,6 @@ namespace MQTTnet.Client
         ///     <remarks>MQTT 5.0.0+ feature.</remarks>
         /// </summary>
         public string AuthenticationMethod { get; set; }
-
-        /// <summary>
-        ///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
-        ///     or WebSocket frames etc. Unfortunately not all brokers (like Amazon Web Services (AWS)) do support this feature and
-        ///     will close the connection when receiving such packets. If such a service is used this flag must
-        ///     be set to _false_.
-        /// </summary>
-        public bool AllowPacketFragmentation { get; set; } = true;
 
         public IMqttClientChannelOptions ChannelOptions { get; set; }
 
@@ -99,6 +99,11 @@ namespace MQTTnet.Client
         ///     <remarks>MQTT 5.0.0+ feature.</remarks>
         /// </summary>
         public uint SessionExpiryInterval { get; set; }
+
+        /// <summary>
+        ///     Gets or sets whether an exception should be thrown when the server has sent a non success ACK packet.
+        /// </summary>
+        public bool ThrowOnNonSuccessfulResponseFromServer { get; set; } = true;
 
         /// <summary>
         ///     Gets or sets the timeout which will be applied at socket level and internal operations.

--- a/Source/MQTTnet/Client/Options/MqttClientOptions.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptions.cs
@@ -103,7 +103,7 @@ namespace MQTTnet.Client
         /// <summary>
         ///     Gets or sets whether an exception should be thrown when the server has sent a non success ACK packet.
         /// </summary>
-        public bool ThrowOnNonSuccessfulResponseFromServer { get; set; } = true;
+        public bool ThrowOnNonSuccessfulConnectResponse { get; set; } = true;
 
         /// <summary>
         ///     Gets or sets the timeout which will be applied at socket level and internal operations.

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs
@@ -78,7 +78,17 @@ namespace MQTTnet.Client
 
             return _options;
         }
-
+        
+        /// <summary>
+        /// The client will not throw an exception when the MQTT server responses with a non success ACK packet.
+        /// This will become the default behavior in future versions of the library.
+        /// </summary>
+        public MqttClientOptionsBuilder WithoutThrowOnNonSuccessfulConnectResponse()
+        {
+            _options.ThrowOnNonSuccessfulConnectResponse = false;
+            return this;
+        }
+        
         public MqttClientOptionsBuilder WithAuthentication(string method, byte[] data)
         {
             _options.AuthenticationMethod = method;


### PR DESCRIPTION
This PR adds a new client option which will avoid that the client throws an exception when connecting and the response from the server is valid but still a non success.