### PR TITLE
Websockets no longer working in Blazor WebAssembly

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,1 +1,1 @@
-* 
+* [Client] Fixed _PlatformNotSupportedException_ when using Blazor (#1755, thanks to @Nickztar).

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -221,11 +221,20 @@ namespace MQTTnet.Implementations
 
 #if !NETSTANDARD1_3
 #if !WINDOWS_UWP
-            clientWebSocket.Options.UseDefaultCredentials = _options.UseDefaultCredentials;
+            if (_options.UseDefaultCredentials)
+            {
+                clientWebSocket.Options.UseDefaultCredentials = _options.UseDefaultCredentials;
+            }
 #endif
-            clientWebSocket.Options.KeepAliveInterval = _options.KeepAliveInterval;
+            if (_options.KeepAliveInterval != WebSocket.DefaultKeepAliveInterval)
+            {
+                clientWebSocket.Options.KeepAliveInterval = _options.KeepAliveInterval;
+            }
 #endif
-            clientWebSocket.Options.Credentials = _options.Credentials;
+            if (_options.Credentials != null)
+            {
+                clientWebSocket.Options.Credentials = _options.Credentials;
+            }
             
             var certificateValidationHandler = _options.TlsOptions?.CertificateValidationHandler;
             if (certificateValidationHandler != null)

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -221,6 +221,8 @@ namespace MQTTnet.Implementations
 
 #if !NETSTANDARD1_3
 #if !WINDOWS_UWP
+            // Only set the value if it is actually true. This property is not supported on all platforms
+            // and will throw a _PlatformNotSupported_ (i.e. WASM) exception when being used regardless of the actual value.
             if (_options.UseDefaultCredentials)
             {
                 clientWebSocket.Options.UseDefaultCredentials = _options.UseDefaultCredentials;


### PR DESCRIPTION
After the latest release Websockets are no longer supported in a Browser platform like Blazor WASM. This is due to the new properties added with https://github.com/dotnet/MQTTnet/pull/1734. These properties are not available on a browser platform and setting them result in the current issue.

This solves this issue by only applying them if they are explictly set. Not sure if this is the best way to solve this. Another option that could have worked is if you could conditionally compile for BROWSER platform but I could not get that work (not sure if it's actually supported?).

This solves my issue. #1754 