### PR TITLE
Fix #1761: MQTTRetainedMessageManager, return task with NULL result instead of NULL

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,1 +1,1 @@
-* 
+* [Server] Fixed _NullReferenceException_ in retained messages management (#1762, thanks to @logicaloud).

--- a/Source/MQTTnet.Tests/Server/MqttRetainedMessageManager_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/MqttRetainedMessageManager_Tests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MQTTnet.Tests.Server
+{
+    [TestClass]
+    public sealed class MqttRetainedMessageManager_Tests
+    {
+        [TestMethod]
+        public async Task MqttRetainedMessageManager_GetUndefinedTopic()
+        {
+            var logger = new Mockups.TestLogger();
+            var eventContainer = new MQTTnet.Server.MqttServerEventContainer();
+            var retainedMessagesManager = new MQTTnet.Server.MqttRetainedMessagesManager(eventContainer, logger);
+            var task = retainedMessagesManager.GetMessage("undefined");
+            Assert.IsNotNull(task, "Task should not be null");
+            var result = await task;
+            Assert.IsNull(result, "Null result expected");
+        }
+    }
+}

--- a/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
@@ -134,9 +134,9 @@ namespace MQTTnet.Server
                 {
                     return Task.FromResult(message);
                 }
-
-                return Task.FromResult((MqttApplicationMessage)null);
             }
+
+            return Task.FromResult<MqttApplicationMessage>(null);
         }
 
         public async Task ClearMessages()

--- a/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttRetainedMessagesManager.cs
@@ -135,7 +135,7 @@ namespace MQTTnet.Server
                     return Task.FromResult(message);
                 }
 
-                return null;
+                return Task.FromResult((MqttApplicationMessage)null);
             }
         }
 


### PR DESCRIPTION
Fixes #1761