### PR TITLE
MQTTRetainedMessageManager improvement proposal

### DIFF
--- a/Samples/Server/Server_Retained_Messages_Samples.cs
+++ b/Samples/Server/Server_Retained_Messages_Samples.cs
@@ -56,7 +56,8 @@ public static class Server_Retained_Messages_Samples
                     // used to write all retained messages to dedicated files etc. Then all files must be loaded and a full list
                     // of retained messages must be provided in the loaded event.
 
-                    var buffer = JsonSerializer.SerializeToUtf8Bytes(eventArgs.StoredRetainedMessages);
+                    var retainedMessages = await server.GetRetainedMessagesAsync();
+                    var buffer = JsonSerializer.SerializeToUtf8Bytes(retainedMessages);
                     await File.WriteAllBytesAsync(storePath, buffer);
                     Console.WriteLine("Retained messages saved.");
                 }

--- a/Source/MQTTnet.TestApp/ServerTest.cs
+++ b/Source/MQTTnet.TestApp/ServerTest.cs
@@ -67,7 +67,8 @@ namespace MQTTnet.TestApp
                         Directory.CreateDirectory(directory);
                     }
 
-                    File.WriteAllText(Filename, JsonConvert.SerializeObject(e.StoredRetainedMessages));
+                    var retainedMessages = mqttServer.GetRetainedMessagesAsync().GetAwaiter().GetResult();
+                    File.WriteAllText(Filename, JsonConvert.SerializeObject(retainedMessages));
                     return CompletedTask.Instance;
                 };
                 

--- a/Source/MQTTnet.Tests/Server/General.cs
+++ b/Source/MQTTnet.Tests/Server/General.cs
@@ -398,7 +398,7 @@ namespace MQTTnet.Tests.Server
                 var s = await testEnvironment.StartServer();
                 s.RetainedMessageChangedAsync += e =>
                 {
-                    savedRetainedMessages = e.StoredRetainedMessages;
+                    savedRetainedMessages = s.GetRetainedMessagesAsync().GetAwaiter().GetResult().ToList();
                     return CompletedTask.Instance;
                 };
 

--- a/Source/MQTTnet.Tests/Server/Retained_Messages_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Retained_Messages_Tests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MQTTnet.Client;
 using MQTTnet.Formatter;
+using MQTTnet.Internal;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
 
@@ -266,6 +267,110 @@ namespace MQTTnet.Tests.Server
                         .Build());
 
                 Assert.IsTrue(connectResult.RetainAvailable);
+            }
+        }
+
+        [TestMethod]
+        public async Task Server_Invokes_Retained_Message_Events()
+        {
+            using (var testEnvironment = CreateTestEnvironment())
+            {
+                const int DefaultPort = 1883;
+
+                var mqttFactory = new MqttFactory();
+                var mqttServerOptions = mqttFactory.CreateServerOptionsBuilder().WithDefaultEndpoint().Build();
+                var server = mqttFactory.CreateMqttServer(mqttServerOptions);
+                
+                // subscribe to retained message events
+
+                int loadMessagesCount = 0;
+                int addMessageCount = 0;
+                int removeMessageCount = 0;
+                int replaceMessageCount = 0;
+                int clearMessagesCount = 0;
+                server.LoadingRetainedMessageAsync += e =>
+                {
+                    loadMessagesCount++;
+                    return CompletedTask.Instance;
+                };
+                server.RetainedMessageChangedAsync += e =>
+                {
+                    switch (e.ChangeType)
+                    {
+                        case MQTTnet.Server.RetainedMessageChangedEventArgs.RetainedMessageChangeType.Add:
+                            addMessageCount++;
+                            break;
+                        case MQTTnet.Server.RetainedMessageChangedEventArgs.RetainedMessageChangeType.Replace:
+                            replaceMessageCount++;
+                            break;
+                        case MQTTnet.Server.RetainedMessageChangedEventArgs.RetainedMessageChangeType.Remove:
+                            removeMessageCount++;
+                            break;
+                    }
+                    return CompletedTask.Instance;
+                };
+                server.RetainedMessagesClearedAsync += e =>
+                {
+                    clearMessagesCount++;
+                    return CompletedTask.Instance;
+                };
+
+                // start server
+                await server.StartAsync();
+
+                // load-event should be invoked when server starts
+                await LongTestDelay();
+                Assert.IsTrue(loadMessagesCount == 1);
+
+                // confirm that "load retained messages" event was triggered
+
+                var client = testEnvironment.CreateClient();
+                var connectResult = await client.ConnectAsync(
+                    testEnvironment.Factory.CreateClientOptionsBuilder()
+                        .WithProtocolVersion(MqttProtocolVersion.V500)
+                        .WithTcpServer("127.0.0.1", DefaultPort)
+                        .Build());
+
+                Assert.IsTrue(connectResult.RetainAvailable);
+
+                // send a message to be retained
+                var msg1 = new MqttApplicationMessageBuilder().WithTopic("topic1").WithPayload(new byte[] { 1, 2, 3 }).WithRetainFlag(true).Build();
+                await client.PublishAsync(msg1);
+
+                // send a message that is not retained
+                var msg2 = new MqttApplicationMessageBuilder().WithTopic("topic2").WithPayload(new byte[] { 4, 5, 6 }).Build();
+                await client.PublishAsync(msg2);
+
+                // send another message to be retained
+                var msg3 = new MqttApplicationMessageBuilder().WithTopic("topic3").WithPayload(new byte[] { 7, 8, 9 }).WithRetainFlag(true).Build();
+                await client.PublishAsync(msg3);
+
+                // two add-messages-events should be received
+                await LongTestDelay();
+                Assert.IsTrue(addMessageCount == 2);
+
+                // update payload to replace retained message
+                msg1.PayloadSegment = new System.ArraySegment<byte>(new byte[3] { 3, 2, 1});
+                await client.PublishAsync(msg1);
+
+                await LongTestDelay();
+                Assert.IsTrue(replaceMessageCount == 1);
+
+                // create empty payload to remove retained message
+                msg1.PayloadSegment = new System.ArraySegment<byte>(new byte[0]);
+                await client.PublishAsync(msg1);
+
+                await LongTestDelay();
+                Assert.IsTrue(removeMessageCount == 1);
+
+                // Deleting all message should result in a clear-messages-event
+                await server.DeleteRetainedMessagesAsync();
+                
+                await LongTestDelay();
+                Assert.IsTrue(clearMessagesCount == 1);
+
+                await client.DisconnectAsync();
+                await server.StopAsync();
             }
         }
     }

--- a/Source/MQTTnet/Server/Events/RetainedMessageChangedEventArgs.cs
+++ b/Source/MQTTnet/Server/Events/RetainedMessageChangedEventArgs.cs
@@ -9,17 +9,19 @@ namespace MQTTnet.Server
 {
     public sealed class RetainedMessageChangedEventArgs : EventArgs
     {
-        public RetainedMessageChangedEventArgs(string clientId, MqttApplicationMessage changedRetainedMessage, List<MqttApplicationMessage> storedRetainedMessages)
+        public enum RetainedMessageChangeType { Add, Remove, Replace };
+
+        public RetainedMessageChangedEventArgs(string clientId,MqttApplicationMessage changedRetainedMessage,  RetainedMessageChangeType changeType)
         {
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
             ChangedRetainedMessage = changedRetainedMessage ?? throw new ArgumentNullException(nameof(changedRetainedMessage));
-            StoredRetainedMessages = storedRetainedMessages ?? throw new ArgumentNullException(nameof(storedRetainedMessages));
+            ChangeType = changeType;
         }
 
         public MqttApplicationMessage ChangedRetainedMessage { get; }
 
         public string ClientId { get; }
 
-        public List<MqttApplicationMessage> StoredRetainedMessages { get; }
+        public RetainedMessageChangeType ChangeType { get; }
     }
 }


### PR DESCRIPTION
Currently the `MQTTRetainedMessageManager` invokes an event to let listeners (i.e. a backing store) know when retained messages have changed. However, events raised in the `UpdateMessage` method do not convey what type of update has been performed, and the backing store would need to implement the same logic as present in the `UpdateMessage` method to replicate the same update action (i.e., check if the application message's payload is empty).

What I'd like to propose is to change the `RetainedMessageChangedEvent` event signature slightly to indicate whether a message has been added, removed or replaced. The `StoredRetainedMessages` member can then be removed from event arguments (breaking change). Relying on the full list of stored retained messages in these events may prevent further improvements in this area.

The included `Server_Invokes_Retained_Message_Events` unit test demonstrates the use of the modified event.

In the future, the `GetMessages` method and associated logic would probably need another look as it demands that all retained messages are made available in memory. Once that is resolved then the need for a separate implementation (i.e. via `IMqttRetainedMessagesManager` as in #1663 or otherwise) may become less relevant.

Any thoughts?

