### PR TITLE
Expose configuration of packet fragmentation in server options.

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,13 +1,1 @@
-* [Core] Add validation of maximum string lengths (#1718).
-* [Core] Added .NET 4.8 builds (#1729).
-* [Core] Exposed more details of DISCONNECT packet in log (#1729).
-* [Core] Fixed _ArgumentNullException_ in _ConvertPayloadToString_ (#1745, thanks to @ramonsmits).
-* [Client] Added overloads for setting packet payload and will payload (#1720).
-* [Client] The proper connect result is now exposed in the _Disconnected_ event when authentication fails (#1139).
-* [Client] Exposed _UseDefaultCredentials_ and more for Web Socket options and proxy options (#1734, thanks to @impworks).
-* [Client] Exposed more TLS options (#1729).
-* [Client] Fixed wrong return code conversion (#1729).
-* [Client] Added an option to avoid throwing an exception when the server returned a proper non success (but valid) response (#1681).
-* [Server] Improved performance by changing internal locking strategy for subscriptions (#1716, thanks to @zeheng).
-* [Server] Fixed exceptions when clients are connecting and disconnecting very fast while accessing the client status for connection validation (#1742).
-* [Server] Exposed more properties in _ClientConnectedEventArgs_ (#1738).
+* 

--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,1 +1,1 @@
-* 
+* [Server] Exposed new option which allows disabling packet fragmentation (#1753).

--- a/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpServerListener.cs
@@ -231,6 +231,7 @@ namespace MQTTnet.Implementations
                     
                     using (var clientAdapter = new MqttChannelAdapter(tcpChannel, packetFormatterAdapter, _rootLogger))
                     {
+                        clientAdapter.AllowPacketFragmentation = _options.AllowPacketFragmentation;
                         await clientHandler(clientAdapter).ConfigureAwait(false);
                     }
                 }
@@ -255,6 +256,7 @@ namespace MQTTnet.Implementations
             {
                 try
                 {
+                    // ReSharper disable once MethodHasAsyncOverload
                     stream?.Dispose();
                     clientSocket?.Dispose();
                 }

--- a/Source/MQTTnet/Server/Options/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet/Server/Options/MqttServerOptionsBuilder.cs
@@ -131,6 +131,18 @@ namespace MQTTnet.Server
             return this;
         }
 
+        /// <summary>
+        ///     Usually the MQTT packets can be send partially to improve memory allocations.
+        ///     This is done by using multiple TCP packets or WebSocket frames etc.
+        ///     Unfortunately not all clients do support this and will close the connection when receiving partial packets.
+        /// </summary>
+        public MqttServerOptionsBuilder WithoutPacketFragmentation()
+        {
+            _options.DefaultEndpointOptions.AllowPacketFragmentation = false;
+            _options.TlsEndpointOptions.AllowPacketFragmentation = false;
+            return this;
+        }
+
         public MqttServerOptionsBuilder WithPersistentSessions(bool value = true)
         {
             _options.EnablePersistentSessions = value;

--- a/Source/MQTTnet/Server/Options/MqttServerTcpEndpointBaseOptions.cs
+++ b/Source/MQTTnet/Server/Options/MqttServerTcpEndpointBaseOptions.cs
@@ -24,6 +24,14 @@ namespace MQTTnet.Server
         public bool? KeepAlive { get; set; }
 
         /// <summary>
+        ///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
+        ///     or WebSocket frames etc. Unfortunately not all clients do support this feature and
+        ///     will close the connection when receiving such packets. If such clients are connecting to this
+        ///     server the flag must be set to _false_.
+        /// </summary>
+        public bool AllowPacketFragmentation { get; set; } = true;
+
+        /// <summary>
         ///     Gets or sets the TCP keep alive interval.
         ///     The value _null_ indicates that the OS and framework defaults should be used.
         /// </summary>


### PR DESCRIPTION
This PR will add a new option in the options builder which allows disabling the packet fragmentation for the server if clients do not support this feature.