### PR TITLE
Moved check on Options.ValidateFeatures below ThrowIf methods to prevent NullReferenceException

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,4 +1,5 @@
 * [Client] Fixed _PlatformNotSupportedException_ when using Blazor (#1755, thanks to @Nickztar).
+* [Client] Fixed _NullReferenceException_ when performing several actions when not connected (#1800, thanks to @ramonsmits).
 * [Server] Fixed _NullReferenceException_ in retained messages management (#1762, thanks to @logicaloud).
 * [Server] Exposed new option which allows disabling packet fragmentation (#1753).
 * [Server] Expired sessions will no longer be used when a client connects (#1756).

--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Connection_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Connection_Tests.cs
@@ -196,5 +196,27 @@ namespace MQTTnet.Tests.Clients.MqttClient
                 Assert.AreEqual(response.UserProperties[0].Value, "Value");
             }
         }
+
+        [TestMethod]
+        public async Task Throw_Proper_Exception_When_Not_Connected()
+        {
+            try
+            {
+                var mqttFactory = new MqttFactory();
+                using (var mqttClient = mqttFactory.CreateMqttClient())
+                {
+                    await mqttClient.SubscribeAsync("test", MqttQualityOfServiceLevel.AtLeastOnce);
+                }
+            }
+            catch (MqttCommunicationException exception)
+            {
+                if (exception.Message == "The client is not connected.")
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail();
+        }
     }
 }

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -321,10 +321,9 @@ namespace MQTTnet.Client
                 MqttTopicValidator.ThrowIfInvalidSubscribe(topicFilter.Topic);
             }
 
-
             ThrowIfDisposed();
             ThrowIfNotConnected();
-
+            
             if (Options.ValidateFeatures)
             {
                 MqttClientSubscribeOptionsValidator.ThrowIfNotSupported(options, _adapter.PacketFormatterAdapter.ProtocolVersion);

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -321,13 +321,14 @@ namespace MQTTnet.Client
                 MqttTopicValidator.ThrowIfInvalidSubscribe(topicFilter.Topic);
             }
 
+
+            ThrowIfDisposed();
+            ThrowIfNotConnected();
+
             if (Options.ValidateFeatures)
             {
                 MqttClientSubscribeOptionsValidator.ThrowIfNotSupported(options, _adapter.PacketFormatterAdapter.ProtocolVersion);
             }
-
-            ThrowIfDisposed();
-            ThrowIfNotConnected();
 
             var subscribePacket = MqttPacketFactories.Subscribe.Create(options);
             subscribePacket.PacketIdentifier = _packetIdentifierProvider.GetNextPacketIdentifier();


### PR DESCRIPTION
Prevent NullReferenceException in the following scenario:

```c#
var mqttFactory = new MqttFactory();
using var mqttClient = mqttFactory.CreateMqttClient();
await mqttClient.SubscribeAsync("test", MqttQualityOfServiceLevel.AtLeastOnce);
```