### PR TITLE
Only logging "Client will now throw an _MqttConnectingFailedException_." warning when actually throwing the exception

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,4 +1,5 @@
 * [Client] Fixed _PlatformNotSupportedException_ when using Blazor (#1755, thanks to @Nickztar).
+* [Client] Fixed wrong logging of obsolete feature when connection was not successful (#1801, thanks to @ramonsmits).
 * [Server] Fixed _NullReferenceException_ in retained messages management (#1762, thanks to @logicaloud).
 * [Server] Exposed new option which allows disabling packet fragmentation (#1753).
 * [Server] Expired sessions will no longer be used when a client connects (#1756).

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -465,11 +465,10 @@ namespace MQTTnet.Client
             // did send a proper ACK packet with a non success response.
             if (options.ThrowOnNonSuccessfulConnectResponse)
             {
-                _logger.Warning(
-                    "Client will now throw an _MqttConnectingFailedException_. This is obsolete and will be removed in the future. Consider setting _ThrowOnNonSuccessfulResponseFromServer=False_ in client options.");
-
                 if (result.ResultCode != MqttClientConnectResultCode.Success)
                 {
+                    _logger.Warning(
+                        "Client will now throw an _MqttConnectingFailedException_. This is obsolete and will be removed in the future. Consider setting _ThrowOnNonSuccessfulResponseFromServer=False_ in client options.");
                     throw new MqttConnectingFailedException($"Connecting with MQTT server failed ({result.ResultCode}).", null, result);
                 }
             }


### PR DESCRIPTION
Warning was always logged while the text states it would throw a `MqttConnectingFailedException` exception.