### PR TITLE
#1810 Close connection after failed connect.

### DIFF
--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -140,6 +140,7 @@ namespace MQTTnet.Client
                 if (connectResult.ResultCode != MqttClientConnectResultCode.Success)
                 {
                     _logger.Warning("Connecting failed: {0}", connectResult.ResultCode);
+                    await DisconnectInternal(null, null, connectResult).ConfigureAwait(false);
                     return connectResult;
                 }
 


### PR DESCRIPTION
If client option `WithoutThrowOnNonSuccessfulConnectResponse` is turned on (and it is expected to be [turned on by default in the future](https://github.com/dotnet/MQTTnet/blob/9295626503231e50310aba104ed94e216ba4e95a/Source/MQTTnet/Client/Options/MqttClientOptionsBuilder.cs#L84)), it will keep client in the _Connecting_ state after failed authentication attempt.

That can cause unexpected behavior, including #1810.

If option `WithoutThrowOnNonSuccessfulConnectResponse` is not turned on, it will work as expected, because the internal client [closes the connection in catch block](https://github.com/dotnet/MQTTnet/blob/9295626503231e50310aba104ed94e216ba4e95a/Source/MQTTnet/Client/MqttClient.cs#L179).

This fix will close the connection correctly if authentication failed.

Tested manually with test code #1810. 