### PR TITLE
Address issue #1818 where MqttConnectionContext throws an error when passed a TcpConnection.

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -3,3 +3,4 @@
 * [Server] Fixed _NullReferenceException_ in retained messages management (#1762, thanks to @logicaloud).
 * [Server] Exposed new option which allows disabling packet fragmentation (#1753).
 * [Server] Expired sessions will no longer be used when a client connects (#1756).
+* [Server] Fixed an issue in connection handling for ASP.NET connections (#1819, thanks to @CZEMacLeod).

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -33,8 +33,11 @@ namespace MQTTnet.AspNetCore
             PacketFormatterAdapter = packetFormatterAdapter ?? throw new ArgumentNullException(nameof(packetFormatterAdapter));
             _connection = connection ?? throw new ArgumentNullException(nameof(connection));
 
-            _input = connection.Transport.Input;
-            _output = connection.Transport.Output;
+            if (!(_connection is TcpConnection tcp) || tcp.IsConnected)
+            {
+                _input = connection.Transport.Input;
+                _output = connection.Transport.Output;
+            }
         }
 
         public long BytesReceived { get; private set; }


### PR DESCRIPTION
By performing the equivalent negative test from `ConnectAsync` in the constructor, the `MessageProcessingMqttConnectionContextBenchmark` benchmark now runs, and you can use `MqttClient` with `MqttClientConnectionContextFactory`.

