### PR TITLE
Adds events for delivered and dropped messages.

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,3 +1,4 @@
 * [Server] Fixed not working _UpdateRetainedMessageAsync_ public api (#1858, thanks to @kimdiego2098).
 * [Client] Added support for custom CA chain validation (#1851, thanks to @rido-min).
 * [Client] Fixed handling of unobserved tasks exceptions (#1871).
+* [Server] Added new events for delivered and dropped messages (#1866, thanks to @kallayj)

--- a/Source/MQTTnet/Internal/MqttPacketBus.cs
+++ b/Source/MQTTnet/Internal/MqttPacketBus.cs
@@ -104,17 +104,22 @@ namespace MQTTnet.Internal
             _signal.Dispose();
         }
 
-        public void DropFirstItem(MqttPacketBusPartition partition)
+        public MqttPacketBusItem DropFirstItem(MqttPacketBusPartition partition)
         {
             lock (_syncRoot)
             {
                 var partitionInstance = _partitions[(int)partition];
 
-                if (partitionInstance.Any())
+                if (partitionInstance.Count > 0)
                 {
+                    var firstItem = partitionInstance.First.Value;
                     partitionInstance.RemoveFirst();
+
+                    return firstItem;
                 }
             }
+
+            return null;
         }
 
         public void EnqueueItem(MqttPacketBusItem item, MqttPacketBusPartition partition)

--- a/Source/MQTTnet/Server/Events/ApplicationMessageEnqueuedEventArgs.cs
+++ b/Source/MQTTnet/Server/Events/ApplicationMessageEnqueuedEventArgs.cs
@@ -8,19 +8,19 @@ namespace MQTTnet.Server
 {
     public sealed class ApplicationMessageEnqueuedEventArgs : EventArgs
     {
-        public ApplicationMessageEnqueuedEventArgs(string senderClientId, string receiverClientId, MqttApplicationMessage applicationMessage, bool dropped)
+        public ApplicationMessageEnqueuedEventArgs(string senderClientId, string receiverClientId, MqttApplicationMessage applicationMessage, bool isDropped)
         {
             SenderClientId = senderClientId ?? throw new ArgumentNullException( nameof(senderClientId));
             ReceiverClientId = receiverClientId ?? throw new ArgumentNullException(nameof(receiverClientId));
-            DroppedQueueFull = dropped;
             ApplicationMessage = applicationMessage ?? throw new ArgumentNullException(nameof(applicationMessage));
+            IsDropped = isDropped;
         }
+
         public string SenderClientId { get; }
 
         public string ReceiverClientId { get; }
 
-        public bool DroppedQueueFull { get; }
-
+        public bool IsDropped { get; }
 
         public MqttApplicationMessage ApplicationMessage { get; }
     }

--- a/Source/MQTTnet/Server/Events/ApplicationMessageEnqueuedEventArgs.cs
+++ b/Source/MQTTnet/Server/Events/ApplicationMessageEnqueuedEventArgs.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MQTTnet.Server
+{
+    public sealed class ApplicationMessageEnqueuedEventArgs : EventArgs
+    {
+        public ApplicationMessageEnqueuedEventArgs(string senderClientId, string receiverClientId, MqttApplicationMessage applicationMessage, bool dropped)
+        {
+            SenderClientId = senderClientId ?? throw new ArgumentNullException( nameof(senderClientId));
+            ReceiverClientId = receiverClientId ?? throw new ArgumentNullException(nameof(receiverClientId));
+            DroppedQueueFull = dropped;
+            ApplicationMessage = applicationMessage ?? throw new ArgumentNullException(nameof(applicationMessage));
+        }
+        public string SenderClientId { get; }
+
+        public string ReceiverClientId { get; }
+
+        public bool DroppedQueueFull { get; }
+
+
+        public MqttApplicationMessage ApplicationMessage { get; }
+    }
+}

--- a/Source/MQTTnet/Server/Events/QueueMessageOverwrittenEventArgs.cs
+++ b/Source/MQTTnet/Server/Events/QueueMessageOverwrittenEventArgs.cs
@@ -3,15 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using MQTTnet.Packets;
 
 namespace MQTTnet.Server
 {
     public sealed class QueueMessageOverwrittenEventArgs : EventArgs
     {
-        public QueueMessageOverwrittenEventArgs(string receiverClientId)
+        public QueueMessageOverwrittenEventArgs(string receiverClientId, MqttPacket packet)
         {
             ReceiverClientId = receiverClientId ?? throw new ArgumentNullException(nameof(receiverClientId));
+            Packet = packet ?? throw new ArgumentNullException(nameof(packet));
         }
+
+        public MqttPacket Packet { get; }
 
         public string ReceiverClientId { get; }
     }

--- a/Source/MQTTnet/Server/Events/QueueMessageOverwrittenEventArgs.cs
+++ b/Source/MQTTnet/Server/Events/QueueMessageOverwrittenEventArgs.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MQTTnet.Server
+{
+    public sealed class QueueMessageOverwrittenEventArgs : EventArgs
+    {
+        public QueueMessageOverwrittenEventArgs(string receiverClientId)
+        {
+            ReceiverClientId = receiverClientId ?? throw new ArgumentNullException(nameof(receiverClientId));
+        }
+
+        public string ReceiverClientId { get; }
+    }
+}

--- a/Source/MQTTnet/Server/Internal/EnqueueDataPacketResult.cs
+++ b/Source/MQTTnet/Server/Internal/EnqueueDataPacketResult.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MQTTnet.Server
+{
+    public enum EnqueueDataPacketResult
+    {
+        Enqueued,
+        Dropped
+    }
+}

--- a/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
@@ -238,7 +238,12 @@ namespace MQTTnet.Server
 
                         matchingSubscribersCount++;
 
-                        session.EnqueueDataPacket(new MqttPacketBusItem(publishPacketCopy));
+                        var result = session.EnqueueDataPacket(new MqttPacketBusItem(publishPacketCopy));
+                        if (_eventContainer.ClientMessageEnqueuedOrDroppedEvent.HasHandlers)
+                        {
+                            var eventArgs = new ApplicationMessageEnqueuedEventArgs(senderId, session.Id, applicationMessage, result);
+                            await _eventContainer.ClientMessageEnqueuedOrDroppedEvent.InvokeAsync(eventArgs).ConfigureAwait(false);
+                        }
                         _logger.Verbose("Client '{0}': Queued PUBLISH packet with topic '{1}'", session.Id, applicationMessage.Topic);
                     }
 

--- a/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
@@ -239,11 +239,13 @@ namespace MQTTnet.Server
                         matchingSubscribersCount++;
 
                         var result = session.EnqueueDataPacket(new MqttPacketBusItem(publishPacketCopy));
-                        if (_eventContainer.ClientMessageEnqueuedOrDroppedEvent.HasHandlers)
+
+                        if (_eventContainer.ApplicationMessageEnqueuedOrDroppedEvent.HasHandlers)
                         {
-                            var eventArgs = new ApplicationMessageEnqueuedEventArgs(senderId, session.Id, applicationMessage, result);
-                            await _eventContainer.ClientMessageEnqueuedOrDroppedEvent.InvokeAsync(eventArgs).ConfigureAwait(false);
+                            var eventArgs = new ApplicationMessageEnqueuedEventArgs(senderId, session.Id, applicationMessage, result == EnqueueDataPacketResult.Dropped);
+                            await _eventContainer.ApplicationMessageEnqueuedOrDroppedEvent.InvokeAsync(eventArgs).ConfigureAwait(false);
                         }
+
                         _logger.Verbose("Client '{0}': Queued PUBLISH packet with topic '{1}'", session.Id, applicationMessage.Topic);
                     }
 

--- a/Source/MQTTnet/Server/Internal/MqttServerEventContainer.cs
+++ b/Source/MQTTnet/Server/Internal/MqttServerEventContainer.cs
@@ -22,6 +22,9 @@ namespace MQTTnet.Server
         public AsyncEvent<ClientUnsubscribedTopicEventArgs> ClientUnsubscribedTopicEvent { get; } = new AsyncEvent<ClientUnsubscribedTopicEventArgs>();
 
         public AsyncEvent<InterceptingClientApplicationMessageEnqueueEventArgs> InterceptingClientEnqueueEvent { get; } = new AsyncEvent<InterceptingClientApplicationMessageEnqueueEventArgs>();
+        public AsyncEvent<ApplicationMessageEnqueuedEventArgs> ClientMessageEnqueuedOrDroppedEvent { get; } = new AsyncEvent<ApplicationMessageEnqueuedEventArgs>();
+
+        public AsyncEvent<QueueMessageOverwrittenEventArgs> QueueMessageOverwrittenEvent { get; } = new AsyncEvent<QueueMessageOverwrittenEventArgs>();
 
         public AsyncEvent<InterceptingPacketEventArgs> InterceptingInboundPacketEvent { get; } = new AsyncEvent<InterceptingPacketEventArgs>();
 

--- a/Source/MQTTnet/Server/Internal/MqttServerEventContainer.cs
+++ b/Source/MQTTnet/Server/Internal/MqttServerEventContainer.cs
@@ -22,9 +22,10 @@ namespace MQTTnet.Server
         public AsyncEvent<ClientUnsubscribedTopicEventArgs> ClientUnsubscribedTopicEvent { get; } = new AsyncEvent<ClientUnsubscribedTopicEventArgs>();
 
         public AsyncEvent<InterceptingClientApplicationMessageEnqueueEventArgs> InterceptingClientEnqueueEvent { get; } = new AsyncEvent<InterceptingClientApplicationMessageEnqueueEventArgs>();
-        public AsyncEvent<ApplicationMessageEnqueuedEventArgs> ClientMessageEnqueuedOrDroppedEvent { get; } = new AsyncEvent<ApplicationMessageEnqueuedEventArgs>();
+        
+        public AsyncEvent<ApplicationMessageEnqueuedEventArgs> ApplicationMessageEnqueuedOrDroppedEvent { get; } = new AsyncEvent<ApplicationMessageEnqueuedEventArgs>();
 
-        public AsyncEvent<QueueMessageOverwrittenEventArgs> QueueMessageOverwrittenEvent { get; } = new AsyncEvent<QueueMessageOverwrittenEventArgs>();
+        public AsyncEvent<QueueMessageOverwrittenEventArgs> QueuedApplicationMessageOverwrittenEvent { get; } = new AsyncEvent<QueueMessageOverwrittenEventArgs>();
 
         public AsyncEvent<InterceptingPacketEventArgs> InterceptingInboundPacketEvent { get; } = new AsyncEvent<InterceptingPacketEventArgs>();
 

--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -91,6 +91,18 @@ namespace MQTTnet.Server
             remove => _eventContainer.InterceptingClientEnqueueEvent.RemoveHandler(value);
         }
 
+        public event Func<ApplicationMessageEnqueuedEventArgs, Task> ClientMessageEnqueuedOrDroppedAsync
+        {
+            add => _eventContainer.ClientMessageEnqueuedOrDroppedEvent.AddHandler(value);
+            remove => _eventContainer.ClientMessageEnqueuedOrDroppedEvent.RemoveHandler(value);
+        }
+
+        public event Func<QueueMessageOverwrittenEventArgs, Task> QueueMessageOverwrittenEventAsync
+        {
+            add => _eventContainer.QueueMessageOverwrittenEvent.AddHandler(value);
+            remove => _eventContainer.QueueMessageOverwrittenEvent.RemoveHandler(value);
+        }
+
         public event Func<InterceptingPacketEventArgs, Task> InterceptingInboundPacketAsync
         {
             add => _eventContainer.InterceptingInboundPacketEvent.AddHandler(value);

--- a/Source/MQTTnet/Server/MqttServer.cs
+++ b/Source/MQTTnet/Server/MqttServer.cs
@@ -49,6 +49,12 @@ namespace MQTTnet.Server
             _keepAliveMonitor = new MqttServerKeepAliveMonitor(options, _clientSessionsManager, _rootLogger);
         }
 
+        public event Func<ApplicationMessageEnqueuedEventArgs, Task> ApplicationMessageEnqueuedOrDroppedAsync
+        {
+            add => _eventContainer.ApplicationMessageEnqueuedOrDroppedEvent.AddHandler(value);
+            remove => _eventContainer.ApplicationMessageEnqueuedOrDroppedEvent.RemoveHandler(value);
+        }
+
         public event Func<ApplicationMessageNotConsumedEventArgs, Task> ApplicationMessageNotConsumedAsync
         {
             add => _eventContainer.ApplicationMessageNotConsumedEvent.AddHandler(value);
@@ -91,18 +97,6 @@ namespace MQTTnet.Server
             remove => _eventContainer.InterceptingClientEnqueueEvent.RemoveHandler(value);
         }
 
-        public event Func<ApplicationMessageEnqueuedEventArgs, Task> ClientMessageEnqueuedOrDroppedAsync
-        {
-            add => _eventContainer.ClientMessageEnqueuedOrDroppedEvent.AddHandler(value);
-            remove => _eventContainer.ClientMessageEnqueuedOrDroppedEvent.RemoveHandler(value);
-        }
-
-        public event Func<QueueMessageOverwrittenEventArgs, Task> QueueMessageOverwrittenEventAsync
-        {
-            add => _eventContainer.QueueMessageOverwrittenEvent.AddHandler(value);
-            remove => _eventContainer.QueueMessageOverwrittenEvent.RemoveHandler(value);
-        }
-
         public event Func<InterceptingPacketEventArgs, Task> InterceptingInboundPacketAsync
         {
             add => _eventContainer.InterceptingInboundPacketEvent.AddHandler(value);
@@ -143,6 +137,12 @@ namespace MQTTnet.Server
         {
             add => _eventContainer.PreparingSessionEvent.AddHandler(value);
             remove => _eventContainer.PreparingSessionEvent.RemoveHandler(value);
+        }
+
+        public event Func<QueueMessageOverwrittenEventArgs, Task> QueuedApplicationMessageOverwrittenAsync
+        {
+            add => _eventContainer.QueuedApplicationMessageOverwrittenEvent.AddHandler(value);
+            remove => _eventContainer.QueuedApplicationMessageOverwrittenEvent.RemoveHandler(value);
         }
 
         public event Func<RetainedMessageChangedEventArgs, Task> RetainedMessageChangedAsync
@@ -215,13 +215,6 @@ namespace MQTTnet.Server
             return _clientSessionsManager.GetClientsStatus();
         }
 
-        public Task<IList<MqttApplicationMessage>> GetRetainedMessagesAsync()
-        {
-            ThrowIfNotStarted();
-
-            return _retainedMessagesManager.GetMessages();
-        }
-
         public Task<MqttApplicationMessage> GetRetainedMessageAsync(string topic)
         {
             if (topic == null)
@@ -232,6 +225,13 @@ namespace MQTTnet.Server
             ThrowIfNotStarted();
 
             return _retainedMessagesManager.GetMessage(topic);
+        }
+
+        public Task<IList<MqttApplicationMessage>> GetRetainedMessagesAsync()
+        {
+            ThrowIfNotStarted();
+
+            return _retainedMessagesManager.GetMessages();
         }
 
         public Task<IList<MqttSessionStatus>> GetSessionsAsync()


### PR DESCRIPTION
There is currently neither unit test coverage nor observability of dropped messages due to a full session queue. Unit test coverage and observability are connected by their common use of an event interface provided by MqttServer.

There is also an observability gap of delivered messages. An InterceptingClientEnqueueEvent handler can set AcceptEnqueue to false, so if one wants to, for example, keep track of the total number of delivered messages InterceptingClientEnqueueEvent is not the conceptually correct event to use.

This change is a proposed enhancement to that event interface to cover these gaps.

The proposal here is to add one distinct event for dropped _old_ messages (i.e. due to a MqttPendingMessagesOverflowStrategy of DropOldestQueuedMessage) and another for enqueued _or_ dropped current message:

1) in the happy case of an enqueued message, a ClientMessageEnqueuedOrDroppedEvent will be raised with a DroppedQueueFull property of false.
2) in the case of dropping the current message, a ClientMessageEnqueuedOrDroppedEvent will be raised with a DroppedQueueFull property of true.
3) in the case of an enqueued message with the overwriting of the oldest message in the queue, a QueueMessageOverwrittenEvent will be raised and then a ClientMessageEnqueuedOrDroppedEvent will be raised with a DroppedQueueFull property of false.

The reason to use one event type for enqueued or dropped new messages is to capture the current message context. In the case of a dropped _old_ message we don't have the full context of the message being dropped. An alternative approach would be to have a dropped message event which will be raised when the queue is full using either MqttPendingMessagesOverflowStrategy, and only include the recipient's id on the event (omitting specific message context).

Or...? Suggestions welcomed.

## TODO
* Unit tests covering the two dropped message scenarios