### PR TITLE
Move "Client is not connected" error to it's own exception

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,3 +1,4 @@
 * [Core] Optimized packet serialization of PUBACK and PUBREC packets for protocol version 5.0.0 (#1939, thanks to @Y-Sindo).
 * [Core] The package inspector is now fully async (#1941).
+* [Client] Added a dedicated exception when the client is not connected (#1954, thanks to @marcpiulachs).
 * [ManagedClient] Added a new event (SubscriptionsChangedAsync) which is fired when a subscription or unsubscription was made (#1894, thanks to @pdufrene).

--- a/Source/MQTTnet/Client/MqttClient.cs
+++ b/Source/MQTTnet/Client/MqttClient.cs
@@ -930,7 +930,7 @@ namespace MQTTnet.Client
 
         static void ThrowNotConnected()
         {
-            throw new MqttCommunicationException("The client is not connected.");
+            throw new MqttClientNotConnectedException();
         }
 
         void TryInitiateDisconnect()

--- a/Source/MQTTnet/Exceptions/MqttClientNotConnectedException.cs
+++ b/Source/MQTTnet/Exceptions/MqttClientNotConnectedException.cs
@@ -6,13 +6,13 @@ using System;
 
 namespace MQTTnet.Exceptions
 {
-    public class MqttClientNotConnectedException :  : MqttCommunicationException
+    public class MqttClientNotConnectedException : MqttCommunicationException
     {
-        public MqttClientNotConnectedException() : base("The client is not connected..")
+        public MqttClientNotConnectedException() : base("The MQTT client is not connected.")
         {
         }
 
-        public MqttClientNotConnectedException(Exception innerException) : base("The client is not connected..", innerException)
+        public MqttClientNotConnectedException(Exception innerException) : base("The MQTT client is not connected.", innerException)
         {
         }
     }

--- a/Source/MQTTnet/Exceptions/MqttClientNotConnectedException.cs
+++ b/Source/MQTTnet/Exceptions/MqttClientNotConnectedException.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MQTTnet.Exceptions
+{
+    public class MqttClientNotConnectedException :  : MqttCommunicationException
+    {
+        public MqttClientNotConnectedException() : base("The client is not connected..")
+        {
+        }
+
+        public MqttClientNotConnectedException(Exception innerException) : base("The client is not connected..", innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Create a custom exception to be able to catch the specific case when the mqtt client is not connected without having to compare the error message comparing strings.

In my application I am catching this type of exception and returning a custom localized error message so I have to catch the more generic MqttCommunicationException exception and compare the exception message for "The client is not connected." string, moving this error to it's own exception makes the solution much more elegant, hope it would be useful to others too.