### PR TITLE
Change behavior of NoMatchingSubscribers

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,4 +1,5 @@
 * [Core] Optimized packet serialization of PUBACK and PUBREC packets for protocol version 5.0.0 (#1939, thanks to @Y-Sindo).
 * [Core] The package inspector is now fully async (#1941).
 * [Client] Added a dedicated exception when the client is not connected (#1954, thanks to @marcpiulachs).
+* [Server] The server will no longer send _NoMatchingSubscribers_ when the actual subscription was non success (#1965, BREAKING CHANGE!). 
 * [ManagedClient] Added a new event (SubscriptionsChangedAsync) which is fired when a subscription or unsubscription was made (#1894, thanks to @pdufrene).

--- a/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet/Server/Internal/MqttClientSessionsManager.cs
@@ -257,7 +257,12 @@ namespace MQTTnet.Server
 
                     if (matchingSubscribersCount == 0)
                     {
-                        reasonCode = (int)MqttPubAckReasonCode.NoMatchingSubscribers;
+                        if (reasonCode == (int)MqttPubAckReasonCode.Success)
+                        {
+                            // Only change the value if it was success. Otherwise, we would hide an error or not authorized status.
+                            reasonCode = (int)MqttPubAckReasonCode.NoMatchingSubscribers;
+                        }
+
                         await FireApplicationMessageNotConsumedEvent(applicationMessage, senderId).ConfigureAwait(false);
                     }
                 }


### PR DESCRIPTION
This PR changes when the server responds with _NoMatchingSubscribers_.
With this change it will only be sent when the initial subscription was a success. 
This avoids hiding error responses which will be rewritten to _NoMatchingSubscribers_ when there are no subscribers.