### PR TITLE
Fix unit tests for topic templates

### DIFF
--- a/Source/MQTTnet.Extensions.TopicTemplate/MqttTopicTemplate.cs
+++ b/Source/MQTTnet.Extensions.TopicTemplate/MqttTopicTemplate.cs
@@ -152,17 +152,28 @@ namespace MQTTnet.Extensions.TopicTemplate
                     }
                 }
                 
-                return a.Substring(0, maxIndex);
+                return a.Substring(0, maxIndex+1);
             }
             
-            foreach (var topic in from template in templates select template.Template)
+            foreach (string topic in from template in templates select template.Template)
             {
                 root = root == null ? topic : CommonPrefix(root, topic);
             }
             
-            root = root ?? "";
+            if (string.IsNullOrEmpty(root))
+                return new MqttTopicTemplate(MqttTopicFilterComparer.MultiLevelWildcard.ToString());
             
-            return new MqttTopicTemplate(root.Substring(0, root.LastIndexOf('/')));
+            if (root.Contains(MqttTopicFilterComparer.LevelSeparator) &&
+                !root.EndsWith(MqttTopicFilterComparer.LevelSeparator.ToString()) &&
+                !root.EndsWith("}"))
+            {
+                root = root.Substring(0, root.LastIndexOf(MqttTopicFilterComparer.LevelSeparator)+1);
+            }
+            
+            if (root.EndsWith(MqttTopicFilterComparer.LevelSeparator.ToString()))
+                root += MqttTopicFilterComparer.SingleLevelWildcard;
+
+            return new MqttTopicTemplate(root);
         }
         
         public override int GetHashCode()


### PR DESCRIPTION
Little to add beyond the title. I previously worked with VS which would not compile the project so the tests were written blindly.

This fixes the tests and a bug in the canonical prefix implementation that was uncovered in the process.  