### PR TITLE
fix: time out and cancel propagation in managed client

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -2,7 +2,8 @@
 * [Core] The package inspector is now fully async (#1941).
 * [Client] Added a dedicated exception when the client is not connected (#1954, thanks to @marcpiulachs).
 * [Client] Exposed the certificate selection event handler in client options (#1984).
-* [Server] The server will no longer send _NoMatchingSubscribers_ when the actual subscription was non success (#1965, BREAKING CHANGE!). 
+* [Server] The server will no longer send _NoMatchingSubscribers_ when the actual subscription was non success (#1965, BREAKING CHANGE!).
 * [Server] Fixed broken support for _null_ in _AddServer_ method in ASP.NET integration (#1981).
 * [ManagedClient] Added a new event (SubscriptionsChangedAsync) which is fired when a subscription or unsubscription was made (#1894, thanks to @pdufrene).
+* [ManagedClient] Fixed race condition when server shuts down while subscribing (#1987, thanks to @marve).
 * [TopicTemplate] Added new extension which provides a template engine for topics (#1932, thanks to @simonthum).


### PR DESCRIPTION
Eliminates race condition that may result in a "hang" on server shutdown. See added unit tests for example scenario.