### PR TITLE
DISCONNECT packet should allow zero-length body

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,5 +1,6 @@
 * [Core] Optimized packet serialization of PUBACK and PUBREC packets for protocol version 5.0.0 (#1939, thanks to @Y-Sindo).
 * [Core] The package inspector is now fully async (#1941).
+* [Core] Fixed decoding of DISCONNECT packet with empty body (#1994, thanks to @Y-Sindo).
 * [Client] Added a dedicated exception when the client is not connected (#1954, thanks to @marcpiulachs).
 * [Client] The client will now throw a _MqttClientUnexpectedDisconnectReceivedException_ when publishing a QoS 0 message which leads to a server disconnect (BREAKING CHANGE!, #1974, thanks to @fazho).
 * [Client] Exposed the certificate selection event handler in client options (#1984).

--- a/Source/MQTTnet/Formatter/V5/MqttV5PacketDecoder.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV5PacketDecoder.cs
@@ -352,7 +352,10 @@ namespace MQTTnet.Formatter.V5
 
         MqttPacket DecodeDisconnectPacket(ArraySegment<byte> body)
         {
-            ThrowIfBodyIsEmpty(body);
+            if (body.Count == 0)
+            {
+                return new MqttDisconnectPacket();
+            }
 
             _bufferReader.SetBuffer(body.Array, body.Offset, body.Count);
 

--- a/Source/MQTTnet/Formatter/V5/MqttV5PacketDecoder.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV5PacketDecoder.cs
@@ -220,7 +220,7 @@ namespace MQTTnet.Formatter.V5
             var packet = new MqttConnectPacket
             {
                 // If the Request Problem Information is absent, the value of 1 is used.
-                RequestProblemInformation = true 
+                RequestProblemInformation = true
             };
 
             var protocolName = _bufferReader.ReadString();
@@ -352,9 +352,15 @@ namespace MQTTnet.Formatter.V5
 
         MqttPacket DecodeDisconnectPacket(ArraySegment<byte> body)
         {
+            // From RFC: 3.14.2.1 Disconnect Reason Code
+            // Byte 1 in the Variable Header is the Disconnect Reason Code.
+            // If the Remaining Length is less than 1 the value of 0x00 (Normal disconnection) is used.
             if (body.Count == 0)
             {
-                return new MqttDisconnectPacket();
+                return new MqttDisconnectPacket
+                {
+                    ReasonCode = MqttDisconnectReasonCode.NormalDisconnection
+                };
             }
 
             _bufferReader.SetBuffer(body.Array, body.Offset, body.Count);
@@ -389,7 +395,7 @@ namespace MQTTnet.Formatter.V5
 
             return packet;
         }
-        
+
         MqttPacket DecodePubAckPacket(ArraySegment<byte> body)
         {
             ThrowIfBodyIsEmpty(body);
@@ -727,7 +733,7 @@ namespace MQTTnet.Formatter.V5
             packet.UserProperties = propertiesReader.CollectedUserProperties;
 
             packet.ReasonCodes = new List<MqttUnsubscribeReasonCode>(_bufferReader.BytesLeft);
-            
+
             while (!_bufferReader.EndOfStream)
             {
                 var reasonCode = (MqttUnsubscribeReasonCode)_bufferReader.ReadByte();


### PR DESCRIPTION
> [If the Remaining Length is less than 1 the value of 0x00 (Normal disconnection) is used.](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901208)