### PR TITLE
Restore old signing to get out hotfix release

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,4 +1,2 @@
 * [Client] Fix _None of the discovered or specified addresses match the socket address family._ (#1997).
 * [Client] Remove the obsolete attribute from the _WithConnectionUri_ methods (#1979).
-
-* All nuget packages are now signed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           sdk-version: 18362
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: |
             3.1.x
@@ -28,13 +28,27 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
+
+      - name: Setup Signing Certificate
+        run: |
+          $secret = '${{ secrets.SNC_BASE64 }}'
+          $decoded = [System.Convert]::FromBase64CharArray($secret, 0, $secret.Length)
+          Set-Content -Path ${{ github.workspace }}\certificate.snk -Value $decoded -AsByteStream
 
       - name: Restore nuget packages
         run: msbuild MQTTnet.sln /t:Restore /p:Configuration="Release" /verbosity:m
 
       - name: Build solution
-        run: msbuild MQTTnet.sln /t:Build /p:Configuration="Release" /verbosity:m /p:FileVersion=${{ env.VERSION }} /p:AssemblyVersion=${{ env.VERSION }} /p:PackageVersion=${{ env.VERSION }}
+        run: msbuild MQTTnet.sln /t:Build /p:Configuration="Release" /verbosity:m /p:FileVersion=${{ env.VERSION }} /p:AssemblyVersion=${{ env.VERSION }} /p:PackageVersion=${{ env.VERSION }} /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=${{ github.workspace }}\certificate.snk
+
+      - name: Collect nuget Packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: nuget Packages
+          path: |
+            **\*.nupkg
+            **\*.snupkg
 
       - name: Setup VSTest
         uses: darenm/Setup-VSTest@v1
@@ -45,32 +59,6 @@ jobs:
       - name: ASP.NET Tests
         run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
 
-      - name: Install sign CLI tool
-        run: dotnet tool install --tool-path . sign --version 0.9.0-beta.23127.3
-
-      - name: Sign nugets
-        shell: pwsh
-        run: >
-          ./sign code azure-key-vault `
-          "**/*.nupkg" `
-          --base-directory "${{ github.workspace }}/Source" `
-          --publisher-name "MQTTnet" `
-          --description "MQTTnet" `
-          --description-url "https://github.com/dotnet/MQTTnet" `
-          --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" `
-          --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" `
-          --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" `
-          --azure-key-vault-certificate "${{ secrets.KEY_VAULT_CERTIFICATE_ID }}" `
-          --azure-key-vault-url "${{ secrets.KEY_VAULT_URL }}"
-        
-      - name: Upload signed nuget packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: signed-nugets
-          path: |
-            ${{ github.workspace }}/Source/**/*.nupkg
-            ${{ github.workspace }}/Source/**/*.snupkg
-
       - name: Publish MyGet nugets
         if: ${{ github.event_name == 'push' }}
-        run: dotnet nuget push ${{ github.workspace }}/Source/**/*.nupkg -k ${{ secrets.MYGET_API_KEY }} -s https://www.myget.org/F/mqttnet/api/v3/index.json --skip-duplicate
+        run: dotnet nuget push **/*.nupkg -k ${{ secrets.MYGET_API_KEY }} -s https://www.myget.org/F/mqttnet/api/v3/index.json --skip-duplicate


### PR DESCRIPTION
This PR restores the old signing code so that a hotfix can be released. Upload to nuget is not working.