### PR TITLE
Restore behavior of _Server_ and _Port_ in client options

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,2 +1,1 @@
-* [Client] Fix _None of the discovered or specified addresses match the socket address family._ (#1997).
-* [Client] Remove the obsolete attribute from the _WithConnectionUri_ methods (#1979).
+* [Client] Restored _Server_ and _Port_ behavior of client options (#2005).

--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
@@ -944,11 +944,12 @@ namespace MQTTnet.Tests.Clients.MqttClient
                 }
             };
 
+            Assert.AreEqual("host:3", options.ChannelOptions.ToString());
             Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
             Assert.AreEqual(3, ((MqttClientTcpOptions)options.ChannelOptions).Port);
 
             options = new MqttClientOptionsBuilder().WithEndPoint(new DnsEndPoint("host", 3)).Build();
-
+            Assert.AreEqual("Unspecified/host:3", options.ChannelOptions.ToString());
             Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
             Assert.AreEqual(3, ((MqttClientTcpOptions)options.ChannelOptions).Port);
 
@@ -956,6 +957,7 @@ namespace MQTTnet.Tests.Clients.MqttClient
 
             Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
             Assert.AreEqual(1883, ((MqttClientTcpOptions)options.ChannelOptions).Port);
+            Assert.AreEqual("Unspecified/host:1883", options.ChannelOptions.ToString());
 
             options = new MqttClientOptionsBuilder().WithTlsOptions(o => o.UseTls()).WithTcpServer("host").Build();
 
@@ -971,7 +973,7 @@ namespace MQTTnet.Tests.Clients.MqttClient
             };
 
             Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
-            Assert.AreEqual(1883, ((MqttClientTcpOptions)options.ChannelOptions).Port);
+            Assert.AreEqual(null, ((MqttClientTcpOptions)options.ChannelOptions).Port);
         }
     }
 }

--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -86,7 +87,7 @@ namespace MQTTnet.Tests.Clients.MqttClient
                 await client.ConnectAsync(clientOptions);
             }
         }
-        
+
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task Connect_Multiple_Times_Should_Fail()
@@ -748,8 +749,8 @@ namespace MQTTnet.Tests.Clients.MqttClient
                 {
                     if (e.ApplicationMessage.Topic == "request")
                     {
-                        // Use AtMostOnce here because with QoS 1 or even QoS 2 the process waits for 
-                        // the ACK etc. The problem is that the SpinUntil below only waits until the 
+                        // Use AtMostOnce here because with QoS 1 or even QoS 2 the process waits for
+                        // the ACK etc. The problem is that the SpinUntil below only waits until the
                         // flag is set. It does not wait until the client has sent the ACK
                         await client2.PublishStringAsync("reply");
                     }
@@ -924,6 +925,53 @@ namespace MQTTnet.Tests.Clients.MqttClient
                 Assert.IsTrue(client1.TryPingAsync().GetAwaiter().GetResult());
                 Assert.IsFalse(disconnectedFired);
             }
+        }
+
+        [TestMethod]
+        public void Backward_compatible_TCP_options()
+        {
+            var options = new MqttClientOptionsBuilder().WithTcpServer("host", 3).Build();
+
+            Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
+            Assert.AreEqual(3, ((MqttClientTcpOptions)options.ChannelOptions).Port);
+
+            options = new MqttClientOptions
+            {
+                ChannelOptions = new MqttClientTcpOptions
+                {
+                    Server = "host",
+                    Port = 3
+                }
+            };
+
+            Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
+            Assert.AreEqual(3, ((MqttClientTcpOptions)options.ChannelOptions).Port);
+
+            options = new MqttClientOptionsBuilder().WithEndPoint(new DnsEndPoint("host", 3)).Build();
+
+            Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
+            Assert.AreEqual(3, ((MqttClientTcpOptions)options.ChannelOptions).Port);
+
+            options = new MqttClientOptionsBuilder().WithTcpServer("host").Build();
+
+            Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
+            Assert.AreEqual(1883, ((MqttClientTcpOptions)options.ChannelOptions).Port);
+
+            options = new MqttClientOptionsBuilder().WithTlsOptions(o => o.UseTls()).WithTcpServer("host").Build();
+
+            Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
+            Assert.AreEqual(8883, ((MqttClientTcpOptions)options.ChannelOptions).Port);
+
+            options = new MqttClientOptions
+            {
+                ChannelOptions = new MqttClientTcpOptions
+                {
+                    Server = "host"
+                }
+            };
+
+            Assert.AreEqual("host", ((MqttClientTcpOptions)options.ChannelOptions).Server);
+            Assert.AreEqual(1883, ((MqttClientTcpOptions)options.ChannelOptions).Port);
         }
     }
 }


### PR DESCRIPTION
This PR restores the behavior of the _Server_ and _Port_ property of the client options.