### PR TITLE
Switch SubscribeAsync/UnsubscribeAsync to IEnumerable<string>

### DIFF
--- a/Source/MQTTnet.Extensions.ManagedClient/IManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/IManagedMqttClient.cs
@@ -47,8 +47,8 @@ namespace MQTTnet.Extensions.ManagedClient
         
         Task StopAsync(bool cleanDisconnect = true);
         
-        Task SubscribeAsync(ICollection<MqttTopicFilter> topicFilters);
+        Task SubscribeAsync(IEnumerable<MqttTopicFilter> topicFilters);
         
-        Task UnsubscribeAsync(ICollection<string> topics);
+        Task UnsubscribeAsync(IEnumerable<string> topics);
     }
 }

--- a/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
+++ b/Source/MQTTnet.Extensions.ManagedClient/ManagedMqttClient.cs
@@ -288,7 +288,7 @@ namespace MQTTnet.Extensions.ManagedClient
             }
         }
 
-        public Task SubscribeAsync(ICollection<MqttTopicFilter> topicFilters)
+        public Task SubscribeAsync(IEnumerable<MqttTopicFilter> topicFilters)
         {
             ThrowIfDisposed();
 
@@ -316,7 +316,7 @@ namespace MQTTnet.Extensions.ManagedClient
             return CompletedTask.Instance;
         }
 
-        public Task UnsubscribeAsync(ICollection<string> topics)
+        public Task UnsubscribeAsync(IEnumerable<string> topics)
         {
             ThrowIfDisposed();
 


### PR DESCRIPTION
The function currently requires an ICollection<string>, but doesn't actually depend on the ICollection<string> interface.  Relax the requirement to be IEnumerable<string> for better flexibility.