### PR TITLE
Support for ReadOnlySequence as payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   sign:
     needs: build
     runs-on: windows-latest # Code signing must run on a Windows agent for Authenticode signing (dll/exe)
-
+    if: github.repository == 'dotnet/MQTTnet'
     steps:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4

--- a/Samples/Server/Server_Retained_Messages_Samples.cs
+++ b/Samples/Server/Server_Retained_Messages_Samples.cs
@@ -6,6 +6,7 @@
 // ReSharper disable UnusedMember.Global
 // ReSharper disable InconsistentNaming
 
+using System.Buffers;
 using System.Text.Json;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
@@ -112,7 +113,7 @@ public static class Server_Retained_Messages_Samples
 
                 // Create a copy of the buffer from the payload segment because
                 // it cannot be serialized and deserialized with the JSON serializer.
-                Payload = message.PayloadSegment.ToArray(),
+                Payload = message.Payload.ToArray(),
                 UserProperties = message.UserProperties,
                 ResponseTopic = message.ResponseTopic,
                 CorrelationData = message.CorrelationData,

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.IO.Pipelines;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -232,14 +233,8 @@ public sealed class MqttConnectionContext : IMqttChannelAdapter
         var span = output.GetSpan(buffer.Length);
 
         buffer.Packet.AsSpan().CopyTo(span);
-
         int offset = buffer.Packet.Count;
-        foreach (var segment in buffer.Payload)
-        {
-            segment.Span.CopyTo(span.Slice(offset));
-            offset += segment.Length;
-        }
-
+        buffer.Payload.CopyTo(destination: span.Slice(offset));
         output.Advance(buffer.Length);
     }
 }

--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -203,7 +203,7 @@ public sealed class MqttConnectionContext : IMqttChannelAdapter
             {
                 var buffer = PacketFormatterAdapter.Encode(packet);
 
-                if (buffer.Payload.Count == 0)
+                if (buffer.Payload.Length == 0)
                 {
                     // zero copy
                     // https://github.com/dotnet/runtime/blob/e31ddfdc4f574b26231233dc10c9a9c402f40590/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs#L279
@@ -232,7 +232,13 @@ public sealed class MqttConnectionContext : IMqttChannelAdapter
         var span = output.GetSpan(buffer.Length);
 
         buffer.Packet.AsSpan().CopyTo(span);
-        buffer.Payload.AsSpan().CopyTo(span.Slice(buffer.Packet.Count));
+
+        int offset = buffer.Packet.Count;
+        foreach (var segment in buffer.Payload)
+        {
+            segment.Span.CopyTo(span.Slice(offset));
+            offset += segment.Length;
+        }
 
         output.Advance(buffer.Length);
     }

--- a/Source/MQTTnet.Benchmarks/MqttTcpChannelBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/MqttTcpChannelBenchmark.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,7 +79,7 @@ public class MqttTcpChannelBenchmark : BaseBenchmark
     {
         await Task.Yield();
 
-        var buffer = new ArraySegment<byte>(new byte[size]);
+        var buffer = new ReadOnlySequence<byte>(new byte[size]);
 
         for (var i = 0; i < iterations; i++)
         {

--- a/Source/MQTTnet.Benchmarks/ReaderExtensionsBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/ReaderExtensionsBenchmark.cs
@@ -36,7 +36,7 @@ namespace MQTTnet.Benchmarks
             var buffer = mqttPacketFormatter.Encode(packet);
             stream = new MemoryStream();
             stream.Write(buffer.Packet);
-            stream.Write(buffer.Payload);
+            stream.Write(buffer.Payload.ToArray());
             mqttPacketFormatter.Cleanup();
         }
 

--- a/Source/MQTTnet.Benchmarks/SendPacketAsyncBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/SendPacketAsyncBenchmark.cs
@@ -2,6 +2,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using MQTTnet.Formatter;
 using System;
+using System.Buffers;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
@@ -40,7 +41,7 @@ namespace MQTTnet.Benchmarks
             stream.Position = 0;
             var output = PipeWriter.Create(stream);
 
-            if (buffer.Payload.Count == 0)
+            if (buffer.Payload.Length == 0)
             {
                 await output.WriteAsync(buffer.Packet).ConfigureAwait(false);
             }
@@ -60,7 +61,7 @@ namespace MQTTnet.Benchmarks
             var span = output.GetSpan(buffer.Length);
 
             buffer.Packet.AsSpan().CopyTo(span);
-            buffer.Payload.AsSpan().CopyTo(span.Slice(buffer.Packet.Count));
+            buffer.Payload.CopyTo(span.Slice(buffer.Packet.Count));
 
             output.Advance(buffer.Length);
         }

--- a/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
@@ -14,6 +14,7 @@ using MQTTnet.Formatter;
 using MQTTnet.Formatter.V3;
 using BenchmarkDotNet.Jobs;
 using MQTTnet.Diagnostics;
+using System.Buffers;
 
 namespace MQTTnet.Benchmarks
 {
@@ -104,7 +105,7 @@ namespace MQTTnet.Benchmarks
                 return Task.FromResult(count);
             }
 
-            public Task WriteAsync(ArraySegment<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken)
+            public Task WriteAsync(ReadOnlySequence<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken)
             {
                 throw new NotSupportedException();
             }

--- a/Source/MQTTnet.Extensions.Rpc/MqttRpcClient.cs
+++ b/Source/MQTTnet.Extensions.Rpc/MqttRpcClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -132,7 +133,7 @@ namespace MQTTnet.Extensions.Rpc
                 return CompletedTask.Instance;
             }
 
-            var payloadBuffer = eventArgs.ApplicationMessage.PayloadSegment.ToArray();
+            var payloadBuffer = eventArgs.ApplicationMessage.Payload.ToArray();
             awaitable.TrySetResult(payloadBuffer);
 
             // Set this message to handled to that other code can avoid execution etc.

--- a/Source/MQTTnet.Server/Internal/Formatter/MqttPublishPacketFactory.cs
+++ b/Source/MQTTnet.Server/Internal/Formatter/MqttPublishPacketFactory.cs
@@ -56,7 +56,7 @@ public static class MqttPublishPacketFactory
         var packet = new MqttPublishPacket
         {
             Topic = applicationMessage.Topic,
-            PayloadSegment = applicationMessage.PayloadSegment,
+            Payload = applicationMessage.Payload,
             QualityOfServiceLevel = applicationMessage.QualityOfServiceLevel,
             Retain = applicationMessage.Retain,
             Dup = applicationMessage.Dup,

--- a/Source/MQTTnet.Server/Internal/MqttRetainedMessagesManager.cs
+++ b/Source/MQTTnet.Server/Internal/MqttRetainedMessagesManager.cs
@@ -65,8 +65,8 @@ namespace MQTTnet.Server.Internal
 
                 lock (_messages)
                 {
-                    var payloadSegment = applicationMessage.PayloadSegment;
-                    var hasPayload = payloadSegment.Count > 0;
+                    var payload = applicationMessage.Payload;
+                    var hasPayload = payload.Length > 0;
 
                     if (!hasPayload)
                     {
@@ -82,7 +82,8 @@ namespace MQTTnet.Server.Internal
                         }
                         else
                         {
-                            if (existingMessage.QualityOfServiceLevel != applicationMessage.QualityOfServiceLevel || !SequenceEqual(existingMessage.PayloadSegment, payloadSegment))
+                            if (existingMessage.QualityOfServiceLevel != applicationMessage.QualityOfServiceLevel ||
+                                !MqttMemoryHelper.SequenceEqual(existingMessage.Payload, payload))
                             {
                                 _messages[applicationMessage.Topic] = applicationMessage;
                                 saveIsRequired = true;
@@ -146,11 +147,6 @@ namespace MQTTnet.Server.Internal
             {
                 await _eventContainer.RetainedMessagesClearedEvent.InvokeAsync(EventArgs.Empty).ConfigureAwait(false);
             }
-        }
-
-        static bool SequenceEqual(ArraySegment<byte> source, ArraySegment<byte> target)
-        {
-            return source.AsSpan().SequenceEqual(target);
         }
     }
 }

--- a/Source/MQTTnet.TestApp/ClientTest.cs
+++ b/Source/MQTTnet.TestApp/ClientTest.cs
@@ -35,12 +35,9 @@ namespace MQTTnet.TestApp
                 client.ApplicationMessageReceivedAsync += e =>
                 {
                     var payloadText = string.Empty;
-                    if (e.ApplicationMessage.PayloadSegment.Count > 0)
+                    if (e.ApplicationMessage.Payload.Length > 0)
                     {
-                        payloadText = Encoding.UTF8.GetString(
-                            e.ApplicationMessage.PayloadSegment.Array,
-                            e.ApplicationMessage.PayloadSegment.Offset,
-                            e.ApplicationMessage.PayloadSegment.Count);
+                        payloadText = Encoding.UTF8.GetString(e.ApplicationMessage.Payload);
                     }
                     
                     Console.WriteLine("### RECEIVED APPLICATION MESSAGE ###");

--- a/Source/MQTTnet.TestApp/ServerTest.cs
+++ b/Source/MQTTnet.TestApp/ServerTest.cs
@@ -145,12 +145,9 @@ namespace MQTTnet.TestApp
                 mqttServer.InterceptingPublishAsync += e =>
                 {
                     var payloadText = string.Empty;
-                    if (e.ApplicationMessage.PayloadSegment.Count > 0)
+                    if (e.ApplicationMessage.Payload.Length > 0)
                     {
-                        payloadText = Encoding.UTF8.GetString(
-                            e.ApplicationMessage.PayloadSegment.Array,
-                            e.ApplicationMessage.PayloadSegment.Offset,
-                            e.ApplicationMessage.PayloadSegment.Count);
+                        payloadText = Encoding.UTF8.GetString(e.ApplicationMessage.Payload);
                     }
 
                     MqttNetConsoleLogger.PrintToConsole($"'{e.ClientId}' reported '{e.ApplicationMessage.Topic}' > '{payloadText}'", ConsoleColor.Magenta);

--- a/Source/MQTTnet.Tests/ASP/MqttConnectionContextTest.cs
+++ b/Source/MQTTnet.Tests/ASP/MqttConnectionContextTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -99,7 +100,7 @@ namespace MQTTnet.Tests.ASP
             connection.Transport = pipe;
             var ctx = new MqttConnectionContext(serializer, connection);
 
-            await ctx.SendPacketAsync(new MqttPublishPacket { PayloadSegment = new ArraySegment<byte>(new byte[20_000]) }, CancellationToken.None).ConfigureAwait(false);
+            await ctx.SendPacketAsync(new MqttPublishPacket { PayloadSegment = new byte[20_000] }, CancellationToken.None).ConfigureAwait(false);
 
             var readResult = await pipe.Send.Reader.ReadAsync();
             Assert.IsTrue(readResult.Buffer.Length > 20000);

--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -297,7 +298,7 @@ namespace MQTTnet.Tests.Clients.MqttClient
 
                 Assert.IsNotNull(receivedMessage);
                 Assert.AreEqual("A", receivedMessage.Topic);
-                Assert.AreEqual(null, receivedMessage.PayloadSegment.Array);
+                Assert.AreEqual(0, receivedMessage.Payload.Length);
             }
         }
 
@@ -508,7 +509,7 @@ namespace MQTTnet.Tests.Clients.MqttClient
 
                 client2.ApplicationMessageReceivedAsync += e =>
                 {
-                    client2TopicResults.Add(Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment.ToArray()));
+                    client2TopicResults.Add(Encoding.UTF8.GetString(e.ApplicationMessage.Payload.ToArray()));
                     return CompletedTask.Instance;
                 };
 

--- a/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
@@ -70,7 +70,26 @@ namespace MQTTnet.Tests.Formatter
             Assert.AreEqual(5, remainingData.Length);
         }
 
-         [TestMethod]
+        [TestMethod]
+        public void Read_Remaining_Payload_From_Larger_Buffer()
+        {
+            var buffer = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            var reader = new MqttBufferReader();
+
+            // The used buffer contains more data than used!
+            reader.SetBuffer(buffer, 0, 5);
+
+            // This should only read 5 bytes even if more data is in the buffer
+            // due to custom bounds.
+            using var remainingData = reader.ReadBufferedPayload();
+
+            Assert.IsTrue(reader.EndOfStream);
+            Assert.AreEqual(0, reader.BytesLeft);
+            Assert.AreEqual(5, remainingData.Sequence.Length);
+        }
+
+        [TestMethod]
         public void Read_Various_Positions_and_Offsets()
         {
             const int NumBufferElements = 1000;

--- a/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
@@ -71,6 +71,25 @@ namespace MQTTnet.Tests.Formatter
         }
 
         [TestMethod]
+        public void Read_Remaining_Payload_From_Larger_Buffer()
+        {
+            var buffer = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            var reader = new MqttBufferReader();
+
+            // The used buffer contains more data than used!
+            reader.SetBuffer(buffer, 0, 5);
+
+            // This should only read 5 bytes even if more data is in the buffer
+            // due to custom bounds.
+            using var remainingData = reader.ReadBufferedPayload();
+
+            Assert.IsTrue(reader.EndOfStream);
+            Assert.AreEqual(0, reader.BytesLeft);
+            Assert.AreEqual(5, remainingData.Sequence.Length);
+        }
+
+        [TestMethod]
         public void Read_Various_Positions_and_Offsets()
         {
             const int NumBufferElements = 1000;

--- a/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
@@ -70,26 +70,7 @@ namespace MQTTnet.Tests.Formatter
             Assert.AreEqual(5, remainingData.Length);
         }
 
-        [TestMethod]
-        public void Read_Remaining_Payload_From_Larger_Buffer()
-        {
-            var buffer = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-
-            var reader = new MqttBufferReader();
-
-            // The used buffer contains more data than used!
-            reader.SetBuffer(buffer, 0, 5);
-
-            // This should only read 5 bytes even if more data is in the buffer
-            // due to custom bounds.
-            using var remainingData = reader.ReadBufferedPayload();
-
-            Assert.IsTrue(reader.EndOfStream);
-            Assert.AreEqual(0, reader.BytesLeft);
-            Assert.AreEqual(5, remainingData.Sequence.Length);
-        }
-
-        [TestMethod]
+         [TestMethod]
         public void Read_Various_Positions_and_Offsets()
         {
             const int NumBufferElements = 1000;

--- a/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttBufferReader_Tests.cs
@@ -70,24 +70,6 @@ namespace MQTTnet.Tests.Formatter
             Assert.AreEqual(5, remainingData.Length);
         }
 
-        [TestMethod]
-        public void Read_Remaining_Payload_From_Larger_Buffer()
-        {
-            var buffer = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-
-            var reader = new MqttBufferReader();
-
-            // The used buffer contains more data than used!
-            reader.SetBuffer(buffer, 0, 5);
-
-            // This should only read 5 bytes even if more data is in the buffer
-            // due to custom bounds.
-            using var remainingData = reader.ReadBufferedPayload();
-
-            Assert.IsTrue(reader.EndOfStream);
-            Assert.AreEqual(0, reader.BytesLeft);
-            Assert.AreEqual(5, remainingData.Sequence.Length);
-        }
 
         [TestMethod]
         public void Read_Various_Positions_and_Offsets()

--- a/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V3_Binary_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V3_Binary_Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -328,7 +329,7 @@ namespace MQTTnet.Tests.Formatter
 
             Assert.IsNotNull(publishPacketCopy);
             Assert.AreEqual(publishPacket.Topic, publishPacketCopy.Topic);
-            CollectionAssert.AreEqual(publishPacket.PayloadSegment.ToArray(), publishPacketCopy.PayloadSegment.ToArray());
+            CollectionAssert.AreEqual(publishPacket.Payload.ToArray(), publishPacketCopy.Payload.ToArray());
 
             // Now modify the payload and test again.
             publishPacket.PayloadSegment = new ArraySegment<byte>(Encoding.UTF8.GetBytes("MQTT"));
@@ -338,7 +339,7 @@ namespace MQTTnet.Tests.Formatter
 
             Assert.IsNotNull(publishPacketCopy2);
             Assert.AreEqual(publishPacket.Topic, publishPacketCopy2.Topic);
-            CollectionAssert.AreEqual(publishPacket.PayloadSegment.ToArray(), publishPacketCopy2.PayloadSegment.ToArray());
+            CollectionAssert.AreEqual(publishPacket.Payload.ToArray(), publishPacketCopy2.Payload.ToArray());
         }
 
         [TestMethod]
@@ -587,7 +588,7 @@ namespace MQTTnet.Tests.Formatter
             return packetFormatterAdapter.ProtocolVersion;
         }
 
-        TPacket Roundtrip<TPacket>(TPacket packet, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311, MqttBufferWriter bufferWriter = null) where TPacket : MqttPacket
+        TPacket Roundtrip<TPacket>(TPacket packet, MqttProtocolVersion protocolVersion = MqttProtocolVersion.V311, MqttBufferReader bufferReader = null, MqttBufferWriter bufferWriter = null) where TPacket : MqttPacket
         {
             var writer = bufferWriter ?? WriterFactory();
             var serializer = MqttPacketFormatterAdapter.GetMqttPacketFormatter(protocolVersion, writer);

--- a/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V3_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V3_Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -322,7 +323,7 @@ namespace MQTTnet.Tests.Formatter
             Assert.AreEqual(publishPacket.PacketIdentifier, deserialized.PacketIdentifier);
             Assert.AreEqual(publishPacket.Dup, deserialized.Dup);
             Assert.AreEqual(publishPacket.Retain, deserialized.Retain);
-            CollectionAssert.AreEqual(publishPacket.PayloadSegment.ToArray(), deserialized.PayloadSegment.ToArray());
+            CollectionAssert.AreEqual(publishPacket.Payload.ToArray(), deserialized.Payload.ToArray());
             Assert.AreEqual(publishPacket.QualityOfServiceLevel, deserialized.QualityOfServiceLevel);
             Assert.AreEqual(publishPacket.Topic, deserialized.Topic);
             Assert.AreEqual(null, deserialized.ResponseTopic); // Not supported in v3.1.1.

--- a/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V5_Tests.cs
+++ b/Source/MQTTnet.Tests/Formatter/MqttPacketSerialization_V5_Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -283,7 +284,7 @@ namespace MQTTnet.Tests.Formatter
             Assert.AreEqual(publishPacket.PacketIdentifier, deserialized.PacketIdentifier);
             Assert.AreEqual(publishPacket.Dup, deserialized.Dup);
             Assert.AreEqual(publishPacket.Retain, deserialized.Retain);
-            CollectionAssert.AreEqual(publishPacket.PayloadSegment.ToArray(), deserialized.PayloadSegment.ToArray());
+            CollectionAssert.AreEqual(publishPacket.Payload.ToArray(), deserialized.Payload.ToArray());
             Assert.AreEqual(publishPacket.QualityOfServiceLevel, deserialized.QualityOfServiceLevel);
             Assert.AreEqual(publishPacket.Topic, deserialized.Topic);
             Assert.AreEqual(publishPacket.ResponseTopic, deserialized.ResponseTopic);

--- a/Source/MQTTnet.Tests/MQTTnet.Tests.csproj
+++ b/Source/MQTTnet.Tests/MQTTnet.Tests.csproj
@@ -14,18 +14,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MSTest.TestAdapter" Version="3.3.1"/>
-        <PackageReference Include="MSTest.TestFramework" Version="3.3.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Source\MQTTnet.Server\MQTTnet.Server.csproj"/>
-        <ProjectReference Include="..\..\Source\MQTTnet.Extensions.Rpc\MQTTnet.Extensions.Rpc.csproj"/>
-        <ProjectReference Include="..\..\Source\MQTTnet\MQTTnet.csproj"/>
-        <ProjectReference Include="..\MQTTnet.AspnetCore\MQTTnet.AspNetCore.csproj"/>
-        <ProjectReference Include="..\MQTTnet.Extensions.TopicTemplate\MQTTnet.Extensions.TopicTemplate.csproj"/>
+        <ProjectReference Include="..\..\Source\MQTTnet.Server\MQTTnet.Server.csproj" />
+        <ProjectReference Include="..\..\Source\MQTTnet.Extensions.Rpc\MQTTnet.Extensions.Rpc.csproj" />
+        <ProjectReference Include="..\..\Source\MQTTnet\MQTTnet.csproj" />
+        <ProjectReference Include="..\MQTTnet.AspnetCore\MQTTnet.AspNetCore.csproj" />
+        <ProjectReference Include="..\MQTTnet.Extensions.TopicTemplate\MQTTnet.Extensions.TopicTemplate.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Source/MQTTnet.Tests/MQTTv5/Client_Tests.cs
+++ b/Source/MQTTnet.Tests/MQTTv5/Client_Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -273,7 +274,7 @@ namespace MQTTnet.Tests.MQTTv5
                 Assert.AreEqual(applicationMessage.ResponseTopic, receivedMessage.ResponseTopic);
                 Assert.AreEqual(applicationMessage.MessageExpiryInterval, receivedMessage.MessageExpiryInterval);
                 CollectionAssert.AreEqual(applicationMessage.CorrelationData, receivedMessage.CorrelationData);
-                CollectionAssert.AreEqual(applicationMessage.PayloadSegment.ToArray(), receivedMessage.PayloadSegment.ToArray());
+                CollectionAssert.AreEqual(applicationMessage.Payload.ToArray(), receivedMessage.Payload.ToArray());
                 CollectionAssert.AreEqual(applicationMessage.UserProperties, receivedMessage.UserProperties);
             }
         }

--- a/Source/MQTTnet.Tests/Mockups/MemoryMqttChannel.cs
+++ b/Source/MQTTnet.Tests/Mockups/MemoryMqttChannel.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using MQTTnet.Channel;
+using MQTTnet.Internal;
+using System.Buffers;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using MQTTnet.Channel;
-using MQTTnet.Internal;
 
 namespace MQTTnet.Tests.Mockups
 {
@@ -47,9 +47,12 @@ namespace MQTTnet.Tests.Mockups
             return _stream.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
-        public Task WriteAsync(ArraySegment<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken)
+        public async Task WriteAsync(ReadOnlySequence<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken)
         {
-            return _stream.WriteAsync(buffer.Array, buffer.Offset, buffer.Count, cancellationToken);
+            foreach (var segment in buffer)
+            {
+                await _stream.WriteAsync(segment, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public void Dispose()

--- a/Source/MQTTnet.Tests/MqttApplicationMessageBuilder_Tests.cs
+++ b/Source/MQTTnet.Tests/MqttApplicationMessageBuilder_Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -30,7 +31,7 @@ namespace MQTTnet.Tests
             Assert.AreEqual("xyz", message.Topic);
             Assert.IsFalse(message.Retain);
             Assert.AreEqual(MqttQualityOfServiceLevel.AtMostOnce, message.QualityOfServiceLevel);
-            Assert.AreEqual(Encoding.UTF8.GetString(message.PayloadSegment.ToArray()), "00:06:00");
+            Assert.AreEqual(Encoding.UTF8.GetString(message.Payload), "00:06:00");
         }
 
         [TestMethod]
@@ -42,7 +43,7 @@ namespace MQTTnet.Tests
             Assert.AreEqual("123", message.Topic);
             Assert.IsFalse(message.Retain);
             Assert.AreEqual(MqttQualityOfServiceLevel.AtMostOnce, message.QualityOfServiceLevel);
-            Assert.AreEqual(Encoding.UTF8.GetString(message.PayloadSegment.ToArray()), "Hello");
+            Assert.AreEqual(Encoding.UTF8.GetString(message.Payload), "Hello");
         }
 
         [TestMethod]

--- a/Source/MQTTnet.Tests/MqttApplicationMessageBuilder_Tests.cs
+++ b/Source/MQTTnet.Tests/MqttApplicationMessageBuilder_Tests.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Buffers;
 using System.IO;
-using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MQTTnet.Protocol;

--- a/Source/MQTTnet.Tests/Server/General.cs
+++ b/Source/MQTTnet.Tests/Server/General.cs
@@ -2,20 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Client;
+using MQTTnet.Internal;
+using MQTTnet.Packets;
+using MQTTnet.Protocol;
+using MQTTnet.Server;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MQTTnet.Adapter;
-using MQTTnet.Client;
-using MQTTnet.Formatter;
-using MQTTnet.Internal;
-using MQTTnet.Packets;
-using MQTTnet.Protocol;
-using MQTTnet.Server;
 
 namespace MQTTnet.Tests.Server
 {
@@ -317,7 +316,7 @@ namespace MQTTnet.Tests.Server
                 var isIntercepted = false;
                 c2.ApplicationMessageReceivedAsync += e =>
                 {
-                    isIntercepted = string.Compare("extended", Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment.ToArray()), StringComparison.Ordinal) == 0;
+                    isIntercepted = string.Compare("extended", Encoding.UTF8.GetString(e.ApplicationMessage.Payload), StringComparison.Ordinal) == 0;
                     return CompletedTask.Instance;
                 };
 
@@ -783,7 +782,7 @@ namespace MQTTnet.Tests.Server
                 var client1 = await testEnvironment.ConnectClient();
                 client1.ApplicationMessageReceivedAsync += e =>
                 {
-                    receivedBody = e.ApplicationMessage.PayloadSegment.ToArray();
+                    receivedBody = e.ApplicationMessage.Payload.ToArray();
                     return CompletedTask.Instance;
                 };
 

--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -228,13 +229,13 @@ public sealed class MqttChannelAdapter : Disposable, IMqttChannelAdapter
 
                 _logger.Verbose("TX ({0} bytes) >>> {1}", packetBuffer.Length, packet);
 
-                if (packetBuffer.Payload.Count == 0 || !AllowPacketFragmentation)
+                if (packetBuffer.Payload.Length == 0 || !AllowPacketFragmentation)
                 {
-                    await _channel.WriteAsync(packetBuffer.Join(), true, cancellationToken).ConfigureAwait(false);
+                    await _channel.WriteAsync(new ReadOnlySequence<byte>(packetBuffer.Join()), true, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    await _channel.WriteAsync(packetBuffer.Packet, false, cancellationToken).ConfigureAwait(false);
+                    await _channel.WriteAsync(new ReadOnlySequence<byte>(packetBuffer.Packet), false, cancellationToken).ConfigureAwait(false);
                     await _channel.WriteAsync(packetBuffer.Payload, true, cancellationToken).ConfigureAwait(false);
                 }
 

--- a/Source/MQTTnet/Channel/IMqttChannel.cs
+++ b/Source/MQTTnet/Channel/IMqttChannel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,5 +23,5 @@ public interface IMqttChannel : IDisposable
 
     Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
-    Task WriteAsync(ArraySegment<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken);
+    Task WriteAsync(ReadOnlySequence<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken);
 }

--- a/Source/MQTTnet/Client/MqttClientExtensions.cs
+++ b/Source/MQTTnet/Client/MqttClientExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -42,6 +43,33 @@ public static class MqttClientExtensions
         this IMqttClient mqttClient,
         string topic,
         IEnumerable<byte> payload = null,
+        MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtMostOnce,
+        bool retain = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (mqttClient == null)
+        {
+            throw new ArgumentNullException(nameof(mqttClient));
+        }
+
+        if (topic == null)
+        {
+            throw new ArgumentNullException(nameof(topic));
+        }
+
+        var applicationMessage = new MqttApplicationMessageBuilder().WithTopic(topic)
+            .WithPayload(payload)
+            .WithRetainFlag(retain)
+            .WithQualityOfServiceLevel(qualityOfServiceLevel)
+            .Build();
+
+        return mqttClient.PublishAsync(applicationMessage, cancellationToken);
+    }
+
+    public static Task<MqttClientPublishResult> PublishSequenceAsync(
+        this IMqttClient mqttClient,
+        string topic,
+        ReadOnlySequence<byte> payload,
         MqttQualityOfServiceLevel qualityOfServiceLevel = MqttQualityOfServiceLevel.AtMostOnce,
         bool retain = false,
         CancellationToken cancellationToken = default)

--- a/Source/MQTTnet/Formatter/MqttApplicationMessageFactory.cs
+++ b/Source/MQTTnet/Formatter/MqttApplicationMessageFactory.cs
@@ -19,7 +19,7 @@ namespace MQTTnet.Formatter
             return new MqttApplicationMessage
             {
                 Topic = publishPacket.Topic,
-                PayloadSegment = publishPacket.PayloadSegment,
+                Payload = publishPacket.Payload,
                 QualityOfServiceLevel = publishPacket.QualityOfServiceLevel,
                 Retain = publishPacket.Retain,
                 Dup = publishPacket.Dup,

--- a/Source/MQTTnet/Formatter/MqttBufferReader.cs
+++ b/Source/MQTTnet/Formatter/MqttBufferReader.cs
@@ -8,7 +8,7 @@ using System.Text;
 using MQTTnet.Exceptions;
 using MQTTnet.Internal;
 using System.Buffers.Binary;
-using MQTTnet.Buffers;
+
 
 namespace MQTTnet.Formatter
 {
@@ -72,21 +72,6 @@ namespace MQTTnet.Formatter
             _position += bufferLength;
 
             return buffer;
-        }
-
-        public IReadOnlySequenceOwner<byte> ReadBufferedPayload()
-        {
-            var bufferLength = BytesLeft;
-            if (bufferLength == 0)
-            {
-                return EmptyReadOnlySequenceOwner<byte>.Empty;
-            }
-
-            var result = ArrayPoolSequenceOwner<byte>.Rent(bufferLength);
-            MqttMemoryHelper.Copy(_buffer, _position, result.Array, 0, bufferLength);
-            _position += bufferLength;
-
-            return result;
         }
 
         public string ReadString()

--- a/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
+++ b/Source/MQTTnet/Formatter/MqttPacketFormatterAdapter.cs
@@ -24,7 +24,8 @@ namespace MQTTnet.Formatter
             _bufferWriter = mqttBufferWriter ?? throw new ArgumentNullException(nameof(mqttBufferWriter));
         }
 
-        public MqttPacketFormatterAdapter(MqttProtocolVersion protocolVersion, MqttBufferWriter bufferWriter) : this(bufferWriter)
+        public MqttPacketFormatterAdapter(MqttProtocolVersion protocolVersion, MqttBufferWriter bufferWriter)
+            : this(bufferWriter)
         {
             UseProtocolVersion(protocolVersion);
         }
@@ -64,18 +65,18 @@ namespace MQTTnet.Formatter
             switch (protocolVersion)
             {
                 case MqttProtocolVersion.V500:
-                {
-                    return new MqttV5PacketFormatter(bufferWriter);
-                }
+                    {
+                        return new MqttV5PacketFormatter(bufferWriter);
+                    }
                 case MqttProtocolVersion.V310:
                 case MqttProtocolVersion.V311:
-                {
-                    return new MqttV3PacketFormatter(bufferWriter, protocolVersion);
-                }
+                    {
+                        return new MqttV3PacketFormatter(bufferWriter, protocolVersion);
+                    }
                 default:
-                {
-                    throw new NotSupportedException();
-                }
+                    {
+                        throw new NotSupportedException();
+                    }
             }
         }
 

--- a/Source/MQTTnet/Formatter/MqttPublishPacketFactory.cs
+++ b/Source/MQTTnet/Formatter/MqttPublishPacketFactory.cs
@@ -22,7 +22,7 @@ namespace MQTTnet.Formatter
             var packet = new MqttPublishPacket
             {
                 Topic = applicationMessage.Topic,
-                PayloadSegment = applicationMessage.PayloadSegment,
+                Payload = applicationMessage.Payload,
                 QualityOfServiceLevel = applicationMessage.QualityOfServiceLevel,
                 Retain = applicationMessage.Retain,
                 Dup = applicationMessage.Dup,

--- a/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
@@ -102,11 +102,15 @@ namespace MQTTnet.Formatter.V3
             var fixedHeader = EncodePacket(packet, _bufferWriter);
             var remainingLength = (uint)(_bufferWriter.Length - 5);
 
-            var publishPacket = packet as MqttPublishPacket;
-            var payloadSegment = publishPacket?.PayloadSegment;
-            if (payloadSegment != null)
+            ReadOnlySequence<byte> payload = default;
+            if (packet is MqttPublishPacket publishPacket)
             {
-                remainingLength += (uint)payloadSegment.Value.Count;
+                payload = publishPacket.Payload;
+                remainingLength += (uint)payload.Length;
+            }
+            else
+            {
+                publishPacket = null;
             }
 
             var remainingLengthSize = MqttBufferWriter.GetVariableByteIntegerSize(remainingLength);
@@ -119,12 +123,11 @@ namespace MQTTnet.Formatter.V3
             _bufferWriter.WriteByte(fixedHeader);
             _bufferWriter.WriteVariableByteInteger(remainingLength);
 
-            var buffer = _bufferWriter.GetBuffer();
-            var firstSegment = new ArraySegment<byte>(buffer, headerOffset, _bufferWriter.Length - headerOffset);
+            var firstSegment = new ArraySegment<byte>(_bufferWriter.GetBuffer(), headerOffset, _bufferWriter.Length - headerOffset);
 
-            return payloadSegment == null
+            return payload.Length == 0
                 ? new MqttPacketBuffer(firstSegment)
-                : new MqttPacketBuffer(firstSegment, payloadSegment.Value);
+                : new MqttPacketBuffer(firstSegment, payload);
         }
 
         MqttPacket DecodeConnAckPacket(ArraySegment<byte> body)

--- a/Source/MQTTnet/Formatter/V5/MqttV5PacketEncoder.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV5PacketEncoder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Linq;
 using MQTTnet.Exceptions;
 using MQTTnet.Packets;
@@ -13,7 +14,7 @@ namespace MQTTnet.Formatter.V5
     public sealed class MqttV5PacketEncoder
     {
         const int FixedHeaderSize = 1;
-        
+
         readonly MqttBufferWriter _bufferWriter;
         readonly MqttV5PropertiesWriter _propertiesWriter = new MqttV5PropertiesWriter(new MqttBufferWriter(1024, 4096));
 
@@ -30,18 +31,22 @@ namespace MQTTnet.Formatter.V5
             }
 
             // Leave enough head space for max header size (fixed + 4 variable remaining length = 5 bytes)
-            _bufferWriter.Reset(5);
-            _bufferWriter.Seek(5);
+            const int ReservedHeaderSize = 5;
+            _bufferWriter.Reset(ReservedHeaderSize);
+            _bufferWriter.Seek(ReservedHeaderSize);
 
             var fixedHeader = EncodePacket(packet);
-            var remainingLength = (uint)_bufferWriter.Length - 5;
+            uint remainingLength = (uint)_bufferWriter.Length - ReservedHeaderSize;
 
-            var publishPacket = packet as MqttPublishPacket;
-            var payloadSegment = publishPacket?.PayloadSegment;
-
-            if (payloadSegment != null)
+            ReadOnlySequence<byte> payload = default;
+            if (packet is MqttPublishPacket publishPacket)
             {
-                remainingLength += (uint)payloadSegment.Value.Count;
+                payload = publishPacket.Payload;
+                remainingLength += (uint)payload.Length;
+            }
+            else
+            {
+                publishPacket = null;
             }
 
             var remainingLengthSize = MqttBufferWriter.GetVariableByteIntegerSize(remainingLength);
@@ -57,9 +62,9 @@ namespace MQTTnet.Formatter.V5
             var buffer = _bufferWriter.GetBuffer();
             var firstSegment = new ArraySegment<byte>(buffer, headerOffset, _bufferWriter.Length - headerOffset);
 
-            return payloadSegment == null
+            return publishPacket == null
                ? new MqttPacketBuffer(firstSegment)
-               : new MqttPacketBuffer(firstSegment, payloadSegment.Value);
+               : new MqttPacketBuffer(firstSegment, publishPacket.Payload);
         }
 
         byte EncodeAuthPacket(MqttAuthPacket packet)

--- a/Source/MQTTnet/Formatter/V5/MqttV5PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV5PacketFormatter.cs
@@ -9,11 +9,12 @@ namespace MQTTnet.Formatter.V5
 {
     public sealed class MqttV5PacketFormatter : IMqttPacketFormatter
     {
-        readonly MqttV5PacketDecoder _decoder = new MqttV5PacketDecoder();
+        readonly MqttV5PacketDecoder _decoder;
         readonly MqttV5PacketEncoder _encoder;
 
         public MqttV5PacketFormatter(MqttBufferWriter bufferWriter)
         {
+            _decoder = new MqttV5PacketDecoder();
             _encoder = new MqttV5PacketEncoder(bufferWriter);
         }
 

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -248,7 +249,7 @@ namespace MQTTnet.Implementations
             }
         }
 
-        public async Task WriteAsync(ArraySegment<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken)
+        public async Task WriteAsync(ReadOnlySequence<byte> buffer, bool isEndOfPacket, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -261,7 +262,10 @@ namespace MQTTnet.Implementations
                     throw new MqttCommunicationException("The TCP connection is closed.");
                 }
 
-                await stream.WriteAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                foreach (var segment in buffer)
+                {
+                    await stream.WriteAsync(segment, cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (ObjectDisposedException)
             {

--- a/Source/MQTTnet/Internal/EmptyBuffer.cs
+++ b/Source/MQTTnet/Internal/EmptyBuffer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 
 namespace MQTTnet.Internal
 {
@@ -11,5 +12,7 @@ namespace MQTTnet.Internal
         public static readonly byte[] Array = System.Array.Empty<byte>();
 
         public static readonly ArraySegment<byte> ArraySegment = new ArraySegment<byte>(Array, 0, 0);
+
+        public static readonly ReadOnlySequence<byte> ReadOnlySequence = ReadOnlySequence<byte>.Empty;
     }
 }

--- a/Source/MQTTnet/Internal/MqttMemoryHelper.cs
+++ b/Source/MQTTnet/Internal/MqttMemoryHelper.cs
@@ -18,30 +18,6 @@ namespace MQTTnet.Internal
             sequence.Slice(sourceIndex).CopyTo(destination.AsSpan(destinationIndex, length));
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Copy(ReadOnlySequence<byte> sequence, int sourceIndex, Memory<byte> destination, int destinationIndex, int length)
-        {
-            var offset = destinationIndex;
-            foreach (var segment in sequence)
-            {
-                if (segment.Length < sourceIndex)
-                {
-                    sourceIndex -= segment.Length;
-                    continue;
-                }
-
-                var targetLength = Math.Min(segment.Length - sourceIndex, length);
-                segment.Span.Slice(sourceIndex, targetLength).CopyTo(destination.Span.Slice(offset));
-                offset += targetLength;
-                length -= targetLength;
-                if (length == 0)
-                {
-                    break;
-                }
-                sourceIndex = 0;
-            }
-        }
-
         public static bool SequenceEqual(ArraySegment<byte> source, ArraySegment<byte> target)
         {
             return source.AsSpan().SequenceEqual(target);

--- a/Source/MQTTnet/Internal/MqttMemoryHelper.cs
+++ b/Source/MQTTnet/Internal/MqttMemoryHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Runtime.CompilerServices;
 
 namespace MQTTnet.Internal
@@ -9,6 +10,102 @@ namespace MQTTnet.Internal
         public static void Copy(byte[] source, int sourceIndex, byte[] destination, int destinationIndex, int length)
         {
             source.AsSpan(sourceIndex, length).CopyTo(destination.AsSpan(destinationIndex, length));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Copy(ReadOnlySequence<byte> sequence, int sourceIndex, byte[] destination, int destinationIndex, int length)
+        {
+            sequence.Slice(sourceIndex).CopyTo(destination.AsSpan(destinationIndex, length));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Copy(ReadOnlySequence<byte> sequence, int sourceIndex, Memory<byte> destination, int destinationIndex, int length)
+        {
+            var offset = destinationIndex;
+            foreach (var segment in sequence)
+            {
+                if (segment.Length < sourceIndex)
+                {
+                    sourceIndex -= segment.Length;
+                    continue;
+                }
+
+                var targetLength = Math.Min(segment.Length - sourceIndex, length);
+                segment.Span.Slice(sourceIndex, targetLength).CopyTo(destination.Span.Slice(offset));
+                offset += targetLength;
+                length -= targetLength;
+                if (length == 0)
+                {
+                    break;
+                }
+                sourceIndex = 0;
+            }
+        }
+
+        public static bool SequenceEqual(ArraySegment<byte> source, ArraySegment<byte> target)
+        {
+            return source.AsSpan().SequenceEqual(target);
+        }
+
+        public static bool SequenceEqual(ReadOnlySequence<byte> source, ReadOnlySequence<byte> target)
+        {
+            if (source.Length != target.Length)
+            {
+                return false;
+            }
+
+            long comparedLength = 0;
+            long length = source.Length;
+
+            int sourceOffset = 0;
+            int targetOffset = 0;
+
+            var sourceEnumerator = source.GetEnumerator();
+            var targetEnumerator = target.GetEnumerator();
+
+            ReadOnlyMemory<byte> sourceSegment = sourceEnumerator.Current;
+            ReadOnlyMemory<byte> targetSegment = targetEnumerator.Current;
+
+            while (true)
+            {
+                int compareLength = Math.Min(sourceSegment.Length - sourceOffset, targetSegment.Length - targetOffset);
+
+                if (compareLength > 0 &&
+                    !sourceSegment.Span.Slice(sourceOffset, compareLength).SequenceEqual(targetSegment.Span.Slice(targetOffset, compareLength)))
+                {
+                    return false;
+                }
+
+                comparedLength += compareLength;
+                if (comparedLength >= length)
+                {
+                    return true;
+                }
+
+                sourceOffset += compareLength;
+                if (sourceOffset >= sourceSegment.Length)
+                {
+                    if (!sourceEnumerator.MoveNext())
+                    {
+                        return false;
+                    }
+
+                    sourceSegment = sourceEnumerator.Current;
+                    sourceOffset = 0;
+                }
+
+                targetOffset += compareLength;
+                if (targetOffset >= targetSegment.Length)
+                {
+                    if (!targetEnumerator.MoveNext())
+                    {
+                        return false;
+                    }
+
+                    targetSegment = targetEnumerator.Current;
+                    targetOffset = 0;
+                }
+            }
         }
     }
 }

--- a/Source/MQTTnet/MqttApplicationMessage.cs
+++ b/Source/MQTTnet/MqttApplicationMessage.cs
@@ -6,6 +6,7 @@ using MQTTnet.Internal;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 namespace MQTTnet
@@ -50,9 +51,17 @@ namespace MQTTnet
         public uint MessageExpiryInterval { get; set; }
 
         /// <summary>
+        /// Set an ArraySegment as Payload.
+        /// </summary>
+        public ArraySegment<byte> PayloadSegment
+        {
+            set { Payload = new ReadOnlySequence<byte>(value); }
+        }
+
+        /// <summary>
         /// Get or set ArraySegment style of Payload.
         /// </summary>
-        public ArraySegment<byte> PayloadSegment { get; set; } = EmptyBuffer.ArraySegment;
+        public ReadOnlySequence<byte> Payload { get; set; } = EmptyBuffer.ReadOnlySequence;
 
         /// <summary>
         ///     Gets or sets the payload format indicator.

--- a/Source/MQTTnet/MqttApplicationMessage.cs
+++ b/Source/MQTTnet/MqttApplicationMessage.cs
@@ -51,7 +51,7 @@ namespace MQTTnet
         public uint MessageExpiryInterval { get; set; }
 
         /// <summary>
-        /// Set an ArraySegment as Payload.
+        ///     Set an ArraySegment as Payload.
         /// </summary>
         public ArraySegment<byte> PayloadSegment
         {
@@ -59,7 +59,10 @@ namespace MQTTnet
         }
 
         /// <summary>
-        /// Get or set ArraySegment style of Payload.
+        ///     Get or set ReadOnlySequence style of Payload.
+        ///     This payload type is used internally and is recommended for public use.
+        ///     It can be used in combination with a RecyclableMemoryStream to publish
+        ///     large buffered messages without allocating large chunks of memory.
         /// </summary>
         public ReadOnlySequence<byte> Payload { get; set; } = EmptyBuffer.ReadOnlySequence;
 

--- a/Source/MQTTnet/MqttApplicationMessageBuilder.cs
+++ b/Source/MQTTnet/MqttApplicationMessageBuilder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,7 +23,7 @@ namespace MQTTnet
         uint _messageExpiryInterval;
 
         MqttPayloadFormatIndicator _payloadFormatIndicator;
-        ArraySegment<byte> _payloadSegment;
+        ReadOnlySequence<byte> _payload;
         MqttQualityOfServiceLevel _qualityOfServiceLevel = MqttQualityOfServiceLevel.AtMostOnce;
         string _responseTopic;
         bool _retain;
@@ -41,7 +42,7 @@ namespace MQTTnet
             var applicationMessage = new MqttApplicationMessage
             {
                 Topic = _topic,
-                PayloadSegment = _payloadSegment,
+                Payload = _payload,
                 QualityOfServiceLevel = _qualityOfServiceLevel,
                 Retain = _retain,
                 ContentType = _contentType,
@@ -89,13 +90,13 @@ namespace MQTTnet
 
         public MqttApplicationMessageBuilder WithPayload(byte[] payload)
         {
-            _payloadSegment = payload == null || payload.Length == 0 ? EmptyBuffer.ArraySegment : new ArraySegment<byte>(payload);
+            _payload = payload == null || payload.Length == 0 ? EmptyBuffer.ReadOnlySequence : new ReadOnlySequence<byte>(payload);
             return this;
         }
 
         public MqttApplicationMessageBuilder WithPayload(ArraySegment<byte> payloadSegment)
         {
-            _payloadSegment = payloadSegment;
+            _payload = new ReadOnlySequence<byte>(payloadSegment);
             return this;
         }
 
@@ -158,6 +159,12 @@ namespace MQTTnet
             return WithPayload(payloadBuffer);
         }
 
+        public MqttApplicationMessageBuilder WithPayload(ReadOnlySequence<byte> payload)
+        {
+            _payload = payload;
+            return this;
+        }
+
         /// <summary>
         ///     Adds the payload format indicator to the message.
         ///     <remarks>MQTT 5.0.0+ feature.</remarks>
@@ -170,7 +177,7 @@ namespace MQTTnet
 
         public MqttApplicationMessageBuilder WithPayloadSegment(ArraySegment<byte> payloadSegment)
         {
-            _payloadSegment = payloadSegment;
+            _payload = new ReadOnlySequence<byte>(payloadSegment);
             return this;
         }
 

--- a/Source/MQTTnet/MqttApplicationMessageExtensions.cs
+++ b/Source/MQTTnet/MqttApplicationMessageExtensions.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Text;
-using MQTTnet.Internal;
 
 namespace MQTTnet;
 
@@ -17,17 +16,11 @@ public static class MqttApplicationMessageExtensions
             throw new ArgumentNullException(nameof(applicationMessage));
         }
 
-        if (applicationMessage.PayloadSegment == EmptyBuffer.ArraySegment)
+        if (applicationMessage.Payload.Length == 0)
         {
             return null;
         }
 
-        if (applicationMessage.PayloadSegment.Array == null)
-        {
-            return null;
-        }
-
-        var payloadSegment = applicationMessage.PayloadSegment;
-        return Encoding.UTF8.GetString(payloadSegment.Array, payloadSegment.Offset, payloadSegment.Count);
+        return Encoding.UTF8.GetString(applicationMessage.Payload);
     }
 }

--- a/Source/MQTTnet/Packets/MqttPublishPacket.cs
+++ b/Source/MQTTnet/Packets/MqttPublishPacket.cs
@@ -21,11 +21,9 @@ public sealed class MqttPublishPacket : MqttPacketWithIdentifier
 
     public MqttPayloadFormatIndicator PayloadFormatIndicator { get; set; } = MqttPayloadFormatIndicator.Unspecified;
 
-    public ArraySegment<byte> PayloadSegment { set { PayloadOwner = null;  Payload = new ReadOnlySequence<byte>(value); } }
+    public ArraySegment<byte> PayloadSegment { set { Payload = new ReadOnlySequence<byte>(value); } }
 
     public ReadOnlySequence<byte> Payload { get; set; }
-
-    public IDisposable PayloadOwner { get; set; }
 
     public MqttQualityOfServiceLevel QualityOfServiceLevel { get; set; } = MqttQualityOfServiceLevel.AtMostOnce;
 

--- a/Source/MQTTnet/Packets/MqttPublishPacket.cs
+++ b/Source/MQTTnet/Packets/MqttPublishPacket.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using MQTTnet.Protocol;
 
@@ -20,7 +21,11 @@ public sealed class MqttPublishPacket : MqttPacketWithIdentifier
 
     public MqttPayloadFormatIndicator PayloadFormatIndicator { get; set; } = MqttPayloadFormatIndicator.Unspecified;
 
-    public ArraySegment<byte> PayloadSegment { get; set; }
+    public ArraySegment<byte> PayloadSegment { set { PayloadOwner = null;  Payload = new ReadOnlySequence<byte>(value); } }
+
+    public ReadOnlySequence<byte> Payload { get; set; }
+
+    public IDisposable PayloadOwner { get; set; }
 
     public MqttQualityOfServiceLevel QualityOfServiceLevel { get; set; } = MqttQualityOfServiceLevel.AtMostOnce;
 
@@ -39,6 +44,6 @@ public sealed class MqttPublishPacket : MqttPacketWithIdentifier
     public override string ToString()
     {
         return
-            $"Publish: [Topic={Topic}] [PayloadLength={PayloadSegment.Count}] [QoSLevel={QualityOfServiceLevel}] [Dup={Dup}] [Retain={Retain}] [PacketIdentifier={PacketIdentifier}]";
+            $"Publish: [Topic={Topic}] [PayloadLength={Payload.Length}] [QoSLevel={QualityOfServiceLevel}] [Dup={Dup}] [Retain={Retain}] [PacketIdentifier={PacketIdentifier}]";
     }
 }


### PR DESCRIPTION
Support `ReadOnlySequence` as a payload in the MQTTnet client, for the new version5 release.

The MQTTNet write method only accepts an `ArraySegment` which is a view into a single buffer. It is currently necessary to call `ToArray` to support a RecyclableMemoryStream.
As a result, perfomance is affected by additional copies and memory is fragment by the additional random allocation of large buffers.

This is a minimal version without lifetime management in the receive code path to get started. 
Since the publish codepath can manage the lifetime of the buffers externally, all publishing applications can already benefit from the implementation.
To minimize the impact on existing code the PayloadSegment setter is kept to convert an ArraySegment to a ReadOnlySequence implicitly, allowing most of the tests to compile unchanged. 

Added also a few tests to show how to use a RecyclableMemoryStream.

see #1917 and #1918 with the issue explained.