### PR TITLE
Setup nuget and code signing for version 4.x.x

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,1 +1,4 @@
-* [nuget] Changed code signing and nuget certificate (**BREAKING CHANGE**)
+* nuget: Changed code signing and nuget certificate (**BREAKING CHANGE**).
+* TopicTemplates: Updated samples, parameter validation (#2022).
+* ManagedClient: Switch SubscribeAsync/UnsubscribeAsync to IEnumerable<string> (#2026).
+* Server: Fix _LoadingRetainedMessageAsync_ not executed (#2025).

--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,1 +1,1 @@
-* [Client] Restored _Server_ and _Port_ behavior of client options (#2005).
+* [nuget] Changed code signing and nuget certificate (**BREAKING CHANGE**)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 env:
   VERSION: "4.3.7.${{github.run_number}}"
-  PACKAGE_SUFFIX: ""
 
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Setup Windows SDK
@@ -25,7 +24,10 @@ jobs:
             6.0.x
             7.0.x
 
-      - name: Checkout code
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Checkout Code
         uses: actions/checkout@v4
 
       - name: Setup Signing Certificate
@@ -40,55 +42,14 @@ jobs:
       - name: Build solution
         run: msbuild MQTTnet.sln /t:Build /p:Configuration="Release" /verbosity:m /p:FileVersion=${{ env.VERSION }} /p:AssemblyVersion=${{ env.VERSION }} /p:PackageVersion=${{ env.VERSION }} /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=${{ github.workspace }}\certificate.snk
 
-     # - name: Setup VSTest
-     #   uses: darenm/Setup-VSTest@v1
+      - name: Setup VSTest
+        uses: darenm/Setup-VSTest@v1
 
-     # - name: Core Tests
-     #   run: vstest.console.exe Source\MQTTnet.Tests\bin\Release\net7.0\MQTTnet.Tests.dll
+      - name: Core Tests
+        run: vstest.console.exe Source\MQTTnet.Tests\bin\Release\net7.0\MQTTnet.Tests.dll
 
-      #- name: ASP.NET Tests
-      #  run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
-
-      - name: Upload nuget packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: nugets
-          path: |
-            ${{ github.workspace }}/Source/**/*.nupkg
-            ${{ github.workspace }}/Source/**/*.snupkg
-
-  test:
-    runs-on: windows-latest
-
-    steps:
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0.x
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Execute tests
-        run: dotnet test --framework net7.0 Source/MQTTnet.Tests/MQTTnet.Tests.csproj
-
-  sign:
-    needs: build
-    runs-on: windows-latest # Code signing must run on a Windows agent for Authenticode signing (dll/exe)
-    if: github.repository == 'dotnet/MQTTnet'
-    steps:
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            6.0.x
-
-      - name: Download nuget packages
-        uses: actions/download-artifact@v4
-        with:
-          name: nugets
-          path: nugets
+      - name: ASP.NET Tests
+        run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
 
       - name: Install sign CLI tool
         run: dotnet tool install --tool-path . sign --version 0.9.0-beta.23127.3
@@ -98,7 +59,7 @@ jobs:
         run: >
           ./sign code azure-key-vault `
           "**/*.nupkg" `
-          --base-directory "${{ github.workspace }}\nugets" `
+          --base-directory "${{ github.workspace }}/Source" `
           --publisher-name "MQTTnet" `
           --description "MQTTnet" `
           --description-url "https://github.com/dotnet/MQTTnet" `
@@ -113,35 +74,9 @@ jobs:
         with:
           name: signed-nugets
           path: |
-            ${{ github.workspace }}\nugets\**\*.nupkg
-            ${{ github.workspace }}\nugets\**\*.snupkg
+            ${{ github.workspace }}/Source/**/*.nupkg
+            ${{ github.workspace }}/Source/**/*.snupkg
 
-  publish-myget:
-    if: ${{ github.event_name == 'push' }}
-    needs: sign
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download signed nuget packages
-        uses: actions/download-artifact@v4
-        with:
-          name: signed-nugets
-          path: nugets
-
-      - name: Publish myget.com nugets
-        run: dotnet nuget push ${{ github.workspace }}/nugets/**/*.nupkg -k ${{ secrets.MYGET_API_KEY }} -s https://www.myget.org/F/mqttnet/api/v3/index.json --skip-duplicate
-
-  publish-nuget:
-    if: ${{ github.event_name == 'release' }}
-    needs: sign
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download signed nuget packages
-        uses: actions/download-artifact@v4
-        with:
-          name: signed-nugets
-          path: nugets
-
-      - name: Publish nuget.org nugets
-        run: dotnet nuget push ${{ github.workspace }}/nugets/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Publish MyGet nugets
+        if: ${{ github.event_name == 'push' }}
+        run: dotnet nuget push ${{ github.workspace }}/Source/**/*.nupkg -k ${{ secrets.MYGET_API_KEY }} -s https://www.myget.org/F/mqttnet/api/v3/index.json --skip-duplicate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,13 @@ name: CI
 on: [push, pull_request]
 
 env:
-  VERSION: "4.3.6.${{github.run_number}}"
+  VERSION: "4.3.7.${{github.run_number}}"
+  PACKAGE_SUFFIX: ""
 
 jobs:
   build:
 
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
       - name: Setup Windows SDK
@@ -17,18 +18,15 @@ jobs:
           sdk-version: 18362
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1.9.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             3.1.x
             6.0.x
             7.0.x
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.1
-
-      - name: Checkout Code
-        uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Setup Signing Certificate
         run: |
@@ -42,23 +40,108 @@ jobs:
       - name: Build solution
         run: msbuild MQTTnet.sln /t:Build /p:Configuration="Release" /verbosity:m /p:FileVersion=${{ env.VERSION }} /p:AssemblyVersion=${{ env.VERSION }} /p:PackageVersion=${{ env.VERSION }} /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=${{ github.workspace }}\certificate.snk
 
-      - name: Collect nuget Packages
-        uses: actions/upload-artifact@v2
+     # - name: Setup VSTest
+     #   uses: darenm/Setup-VSTest@v1
+
+     # - name: Core Tests
+     #   run: vstest.console.exe Source\MQTTnet.Tests\bin\Release\net7.0\MQTTnet.Tests.dll
+
+      #- name: ASP.NET Tests
+      #  run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
+
+      - name: Upload nuget packages
+        uses: actions/upload-artifact@v4
         with:
-          name: nuget Packages
+          name: nugets
           path: |
-            **\*.nupkg
-            **\*.snupkg
+            ${{ github.workspace }}/Source/**/*.nupkg
+            ${{ github.workspace }}/Source/**/*.snupkg
 
-      - name: Setup VSTest
-        uses: darenm/Setup-VSTest@v1
+  test:
+    runs-on: windows-latest
 
-      - name: Core Tests
-        run: vstest.console.exe Source\MQTTnet.Tests\bin\Release\net7.0\MQTTnet.Tests.dll
+    steps:
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
 
-      - name: ASP.NET Tests
-        run: vstest.console.exe Source\MQTTnet.AspNetCore.Tests\bin\Release\netcoreapp3.1\MQTTnet.AspNetCore.Tests.dll
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Publish MyGet nugets
-        if: ${{ github.event_name == 'push' }}
-        run: dotnet nuget push **/*.nupkg -k ${{ secrets.MYGET_API_KEY }} -s https://www.myget.org/F/mqttnet/api/v3/index.json --skip-duplicate
+      - name: Execute tests
+        run: dotnet test --framework net7.0 Source/MQTTnet.Tests/MQTTnet.Tests.csproj
+
+  sign:
+    needs: build
+    runs-on: windows-latest # Code signing must run on a Windows agent for Authenticode signing (dll/exe)
+    if: github.repository == 'dotnet/MQTTnet'
+    steps:
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+
+      - name: Download nuget packages
+        uses: actions/download-artifact@v4
+        with:
+          name: nugets
+          path: nugets
+
+      - name: Install sign CLI tool
+        run: dotnet tool install --tool-path . sign --version 0.9.0-beta.23127.3
+
+      - name: Sign nugets
+        shell: pwsh
+        run: >
+          ./sign code azure-key-vault `
+          "**/*.nupkg" `
+          --base-directory "${{ github.workspace }}\nugets" `
+          --publisher-name "MQTTnet" `
+          --description "MQTTnet" `
+          --description-url "https://github.com/dotnet/MQTTnet" `
+          --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" `
+          --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" `
+          --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" `
+          --azure-key-vault-certificate "${{ secrets.KEY_VAULT_CERTIFICATE_ID }}" `
+          --azure-key-vault-url "${{ secrets.KEY_VAULT_URL }}"
+
+      - name: Upload signed nuget packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed-nugets
+          path: |
+            ${{ github.workspace }}\nugets\**\*.nupkg
+            ${{ github.workspace }}\nugets\**\*.snupkg
+
+  publish-myget:
+    if: ${{ github.event_name == 'push' }}
+    needs: sign
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download signed nuget packages
+        uses: actions/download-artifact@v4
+        with:
+          name: signed-nugets
+          path: nugets
+
+      - name: Publish myget.com nugets
+        run: dotnet nuget push ${{ github.workspace }}/nugets/**/*.nupkg -k ${{ secrets.MYGET_API_KEY }} -s https://www.myget.org/F/mqttnet/api/v3/index.json --skip-duplicate
+
+  publish-nuget:
+    if: ${{ github.event_name == 'release' }}
+    needs: sign
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download signed nuget packages
+        uses: actions/download-artifact@v4
+        with:
+          name: signed-nugets
+          path: nugets
+
+      - name: Publish nuget.org nugets
+        run: dotnet nuget push ${{ github.workspace }}/nugets/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/MQTTnet.sln
+++ b/MQTTnet.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CODE-OF-CONDUCT.md = CODE-OF-CONDUCT.md
 		LICENSE = LICENSE
 		README.md = README.md
+		.github\workflows\ReleaseNotes.md = .github\workflows\ReleaseNotes.md
+		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MQTTnet.AspNetCore", "Source\MQTTnet.AspnetCore\MQTTnet.AspNetCore.csproj", "{F10C4060-F7EE-4A83-919F-FF723E72F94A}"


### PR DESCRIPTION
This PR changes the CI so that nugets for version 4.x.x are also signed with the same certificate as version 5.x.x.