### PR TITLE
Set max pending mesages per client to 1000

### DIFF
--- a/Source/MQTTnet.Server/Options/MqttServerOptions.cs
+++ b/Source/MQTTnet.Server/Options/MqttServerOptions.cs
@@ -2,38 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+namespace MQTTnet.Server;
 
-namespace MQTTnet.Server
+public sealed class MqttServerOptions
 {
-    public sealed class MqttServerOptions
-    {
-        public TimeSpan DefaultCommunicationTimeout { get; set; } = TimeSpan.FromSeconds(100);
+    public TimeSpan DefaultCommunicationTimeout { get; set; } = TimeSpan.FromSeconds(100);
 
-        public MqttServerTcpEndpointOptions DefaultEndpointOptions { get; } = new MqttServerTcpEndpointOptions();
+    public MqttServerTcpEndpointOptions DefaultEndpointOptions { get; } = new();
 
-        public bool EnablePersistentSessions { get; set; }
+    public bool EnablePersistentSessions { get; set; }
 
-        public MqttServerKeepAliveOptions KeepAliveOptions { get; } = new MqttServerKeepAliveOptions();
+    public MqttServerKeepAliveOptions KeepAliveOptions { get; } = new();
 
-        public int MaxPendingMessagesPerClient { get; set; } = 250;
+    public int MaxPendingMessagesPerClient { get; set; } = 1000;
 
-        public MqttPendingMessagesOverflowStrategy PendingMessagesOverflowStrategy { get; set; } = MqttPendingMessagesOverflowStrategy.DropOldestQueuedMessage;
+    public MqttPendingMessagesOverflowStrategy PendingMessagesOverflowStrategy { get; set; } = MqttPendingMessagesOverflowStrategy.DropOldestQueuedMessage;
 
-        public MqttServerTlsTcpEndpointOptions TlsEndpointOptions { get; } = new MqttServerTlsTcpEndpointOptions();
+    public MqttServerTlsTcpEndpointOptions TlsEndpointOptions { get; } = new();
 
-        /// <summary>
-        ///     Gets or sets the default and initial size of the packet write buffer.
-        ///     It is recommended to set this to a value close to the usual expected packet size * 1.5.
-        ///     Do not change this value when no memory issues are experienced.
-        /// </summary>
-        public int WriterBufferSize { get; set; } = 4096;
+    /// <summary>
+    ///     Gets or sets the default and initial size of the packet write buffer.
+    ///     It is recommended to set this to a value close to the usual expected packet size * 1.5.
+    ///     Do not change this value when no memory issues are experienced.
+    /// </summary>
+    public int WriterBufferSize { get; set; } = 4096;
 
-        /// <summary>
-        ///     Gets or sets the maximum size of the buffer writer. The writer will reduce its internal buffer
-        ///     to this value after serializing a packet.
-        ///     Do not change this value when no memory issues are experienced.
-        /// </summary>
-        public int WriterBufferSizeMax { get; set; } = 65535;
-    }
+    /// <summary>
+    ///     Gets or sets the maximum size of the buffer writer. The writer will reduce its internal buffer
+    ///     to this value after serializing a packet.
+    ///     Do not change this value when no memory issues are experienced.
+    /// </summary>
+    public int WriterBufferSizeMax { get; set; } = 65535;
 }

--- a/Source/ReleaseNotes.md
+++ b/Source/ReleaseNotes.md
@@ -8,3 +8,4 @@
 * Namespace changes **(BREAKING CHANGE)**
 * Removal of Managed Client **(BREAKING CHANGE)**
 * Client: MQTT 5.0.0 is now the default version when connecting with a server **(BREAKING CHANGE)**
+* Server: Set default for "MaxPendingMessagesPerClient" to 1000 **(BREAKING CHANGE)**


### PR DESCRIPTION
This PR changes the default value of the maximum pending messages per client to 1000.
This is required because 250 is not enough even for some samples.