### PR TITLE
Fix ignored exceptions in MqttHostedServer startup

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttHostedServer.cs
+++ b/Source/MQTTnet.AspnetCore/MqttHostedServer.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using MQTTnet.Diagnostics.Logger;
 using MQTTnet.Server;
 
@@ -16,16 +18,20 @@ public sealed class MqttHostedServer : MqttServer, IHostedService
 {
     readonly IHostApplicationLifetime _hostApplicationLifetime;
     readonly MqttServerFactory _mqttFactory;
+    readonly ILogger _appLogger;
 
     public MqttHostedServer(
         IHostApplicationLifetime hostApplicationLifetime,
         MqttServerFactory mqttFactory,
         MqttServerOptions options,
         IEnumerable<IMqttServerAdapter> adapters,
-        IMqttNetLogger logger) : base(options, adapters, logger)
+        IMqttNetLogger logger,
+        ILogger<MqttHostedServer> appLogger = null
+        ) : base(options, adapters, logger)
     {
         _mqttFactory = mqttFactory ?? throw new ArgumentNullException(nameof(mqttFactory));
         _hostApplicationLifetime = hostApplicationLifetime;
+        _appLogger = appLogger ?? NullLogger<MqttHostedServer>.Instance;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -43,6 +49,19 @@ public sealed class MqttHostedServer : MqttServer, IHostedService
 
     void OnStarted()
     {
-        _ = StartAsync();
+        async Task DoStart()
+        {
+            try
+            {
+                await StartAsync();
+            }
+            catch (Exception e)
+            {
+                _appLogger.LogError(e, "Stopping application: failed to start MqttServer: {Error}", e.Message);
+                _hostApplicationLifetime.StopApplication();
+                throw;
+            }
+        }
+        _ = DoStart();
     }
 }


### PR DESCRIPTION
The exceptions raised during the startup of `MqttHostedServer` are completely ignored.
Nothing on the logs, the application continue to run, and the `MqttServer.StartedAsync` event is never raised leaving the application in an inconsistent state...
I found this issue because in my application I'm also using the Tcp endpoint (on the default port 1883), but if the port is already in use obviously the Tcp listener fails with an exception.

This PR fixes the issue shutting down the application in this case.
If the user has a service registration for `Microsoft.Extensions.Logging.ILogger` (quite common in real life scenario) an error is also logged.

