### PR TITLE
Set the default value of SslProtocol to SslProtocols.None.

### DIFF
--- a/Source/MQTTnet.Server/Options/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet.Server/Options/MqttServerTlsTcpEndpointOptions.cs
@@ -22,7 +22,7 @@ namespace MQTTnet.Server
 
         public bool CheckCertificateRevocation { get; set; }
 
-        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls12;
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.None;
 
         public System.Net.Security.CipherSuitesPolicy CipherSuitesPolicy { get; set; }
     }

--- a/Source/MQTTnet.Server/Options/MqttServerTlsTcpEndpointOptions.cs
+++ b/Source/MQTTnet.Server/Options/MqttServerTlsTcpEndpointOptions.cs
@@ -22,6 +22,10 @@ namespace MQTTnet.Server
 
         public bool CheckCertificateRevocation { get; set; }
 
+        /// <summary>
+        /// The default value is SslProtocols.None, which allows the operating system to choose the best protocol to use, and to block protocols that are not secure.
+        /// </summary>
+        /// <seealso href="https://learn.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols">SslProtocols</seealso>       
         public SslProtocols SslProtocol { get; set; } = SslProtocols.None;
 
         public System.Net.Security.CipherSuitesPolicy CipherSuitesPolicy { get; set; }


### PR DESCRIPTION
SslProtocols.None: 
Allows the operating system to choose the best protocol to use, and to block  protocols that are not secure. Unless your app has a specific reason not to,  you should use this field.

