### PR TITLE
Improve the compatibility of MqttClientOptionsBuilder.WithConnectionUri()

### DIFF
--- a/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
@@ -139,22 +139,38 @@ public sealed class MqttClientOptionsBuilder
             case "tcp":
             case "mqtt":
                 WithTcpServer(uri.Host, port)
+                    .WithAddressFamily(AddressFamily.Unspecified)
+                    .WithProtocolType(ProtocolType.Tcp)
                     .WithTlsOptions(o => o.UseTls(false));
                 break;
 
             case "mqtts":
                 WithTcpServer(uri.Host, port)
+                    .WithAddressFamily(AddressFamily.Unspecified)
+                    .WithProtocolType(ProtocolType.Tcp)
                     .WithTlsOptions(o => o.UseTls(true));
                 break;
 
             case "ws":
                 WithWebSocketServer(o => o.WithUri(uri.ToString()))
+                    .WithAddressFamily(AddressFamily.Unspecified)
+                    .WithProtocolType(ProtocolType.Tcp)
                     .WithTlsOptions(o => o.UseTls(false));
                 break;
 
             case "wss":
                 WithWebSocketServer(o => o.WithUri(uri.ToString()))
+                    .WithAddressFamily(AddressFamily.Unspecified)
+                    .WithProtocolType(ProtocolType.Tcp)
                     .WithTlsOptions(o => o.UseTls(true));
+                break;
+
+            // unix:///path/to/socket
+            case "unix":
+                WithEndPoint(new UnixDomainSocketEndPoint(uri.AbsolutePath))
+                    .WithAddressFamily(AddressFamily.Unix)
+                    .WithProtocolType(ProtocolType.Unspecified)
+                    .WithTlsOptions(o => o.UseTls(false));
                 break;
 
             default:

--- a/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
@@ -1,15 +1,15 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using MQTTnet.Formatter;
+using MQTTnet.Packets;
+using MQTTnet.Protocol;
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using MQTTnet.Formatter;
-using MQTTnet.Packets;
-using MQTTnet.Protocol;
 
 namespace MQTTnet;
 
@@ -138,20 +138,22 @@ public sealed class MqttClientOptionsBuilder
         {
             case "tcp":
             case "mqtt":
-                WithTcpServer(uri.Host, port);
+                WithTcpServer(uri.Host, port)
+                    .WithTlsOptions(default(MqttClientTlsOptions));
                 break;
 
             case "mqtts":
                 WithTcpServer(uri.Host, port)
-                    .WithTlsOptions(
-                        o =>
-                        {
-                        });
+                    .WithTlsOptions(o => { });
                 break;
 
             case "ws":
+                WithWebSocketServer(o => o.WithUri(uri.ToString()))
+                    .WithTlsOptions(default(MqttClientTlsOptions));
+                break;
             case "wss":
-                WithWebSocketServer(o => o.WithUri(uri.ToString()));
+                WithWebSocketServer(o => o.WithUri(uri.ToString()))
+                    .WithTlsOptions(o => { });
                 break;
 
             default:

--- a/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
@@ -139,21 +139,22 @@ public sealed class MqttClientOptionsBuilder
             case "tcp":
             case "mqtt":
                 WithTcpServer(uri.Host, port)
-                    .WithTlsOptions(default(MqttClientTlsOptions));
+                    .WithTlsOptions(o => o.UseTls(false));
                 break;
 
             case "mqtts":
                 WithTcpServer(uri.Host, port)
-                    .WithTlsOptions(o => { });
+                    .WithTlsOptions(o => o.UseTls(true));
                 break;
 
             case "ws":
                 WithWebSocketServer(o => o.WithUri(uri.ToString()))
-                    .WithTlsOptions(default(MqttClientTlsOptions));
+                    .WithTlsOptions(o => o.UseTls(false));
                 break;
+
             case "wss":
                 WithWebSocketServer(o => o.WithUri(uri.ToString()))
-                    .WithTlsOptions(o => { });
+                    .WithTlsOptions(o => o.UseTls(true));
                 break;
 
             default:

--- a/Source/MQTTnet/Options/MqttClientWebSocketOptionsBuilder.cs
+++ b/Source/MQTTnet/Options/MqttClientWebSocketOptionsBuilder.cs
@@ -66,6 +66,12 @@ public sealed class MqttClientWebSocketOptionsBuilder
 
     public MqttClientWebSocketOptionsBuilder WithUri(string uri)
     {
+        var webSocketUri = new Uri(uri, UriKind.Absolute);
+        if (webSocketUri.Scheme != Uri.UriSchemeWs && webSocketUri.Scheme != Uri.UriSchemeWss)
+        {
+            throw new ArgumentException("The scheme of the WebSocket Uri must be ws or wss.");
+        }
+
         _webSocketOptions.Uri = uri;
         return this;
     }


### PR DESCRIPTION
We should configure WithTlsOptions() additionally for each scheme.