### PR TITLE
Reduce memory allocation of DecodePublishPacket.

### DIFF
--- a/Source/MQTTnet/Formatter/MqttBufferReader.cs
+++ b/Source/MQTTnet/Formatter/MqttBufferReader.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.CompilerServices;
-using System.Text;
 using MQTTnet.Exceptions;
 using MQTTnet.Internal;
+using System;
 using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 
 namespace MQTTnet.Formatter
@@ -72,6 +72,12 @@ namespace MQTTnet.Formatter
             _position += bufferLength;
 
             return buffer;
+        }
+
+        public ArraySegment<byte> ReadRemainingDataSegment()
+        {
+            var bufferLength = BytesLeft;
+            return bufferLength == 0 ? EmptyBuffer.ArraySegment : new ArraySegment<byte>(_buffer, _position, bufferLength);
         }
 
         public string ReadString()

--- a/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
@@ -2,15 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using MQTTnet.Adapter;
+using MQTTnet.Exceptions;
+using MQTTnet.Packets;
+using MQTTnet.Protocol;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using MQTTnet.Adapter;
-using MQTTnet.Exceptions;
-using MQTTnet.Packets;
-using MQTTnet.Protocol;
 
 namespace MQTTnet.Formatter.V3
 {
@@ -279,7 +279,7 @@ namespace MQTTnet.Formatter.V3
 
             if (!_bufferReader.EndOfStream)
             {
-                packet.PayloadSegment = new ArraySegment<byte>(_bufferReader.ReadRemainingData());
+                packet.PayloadSegment = _bufferReader.ReadRemainingDataSegment();
             }
 
             return packet;

--- a/Source/MQTTnet/Formatter/V5/MqttV5PacketDecoder.cs
+++ b/Source/MQTTnet/Formatter/V5/MqttV5PacketDecoder.cs
@@ -540,7 +540,7 @@ namespace MQTTnet.Formatter.V5
 
             if (!_bufferReader.EndOfStream)
             {
-                packet.PayloadSegment = new ArraySegment<byte>(_bufferReader.ReadRemainingData());
+                packet.PayloadSegment = _bufferReader.ReadRemainingDataSegment();
             }
 
             return packet;


### PR DESCRIPTION
Now, memory allocation is reduced to 50%.
Job=.NET 8.0  Runtime=.NET 8.0  
 
| Method                        | PayloadSize | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0       | Gen1      | Allocated | Alloc Ratio |
|------------------------------ |------------ |----------:|----------:|----------:|------:|--------:|-----------:|----------:|----------:|------------:|
| **Send_1000_Messages_New** | **8192**        |  **8.727 ms** | **0.1393 ms** | **0.1368 ms** |  **1.00** |    **0.00** |  **1875.0000** |   **62.5000** |   **8.55 MB** |        **1.00** |
| Send_1000_Messages_Old    | 8192        | 18.182 ms | 0.1461 ms | 0.1220 ms |  2.08 |    0.03 |  3593.7500 |  250.0000 |  16.89 MB |        1.98 |
|                               |             |           |           |           |       |         |            |           |           |             |
| **Send_1000_Messages_New** | **65536**       | **40.791 ms** | **0.8041 ms** | **1.8475 ms** |  **1.00** |    **0.00** | **11076.9231** | **3307.6923** |  **63.22 MB** |        **1.00** |
| Send_1000_Messages_Old    | 65536       | 32.204 ms | 0.6323 ms | 0.7997 ms |  0.79 |    0.04 | 21200.0000 | 7066.6667 | 127.05 MB |        2.01 |
