### PR TITLE
MqttClientFactory: Fix CreateLowLevelMqttClient not using method parameters

### DIFF
--- a/Source/MQTTnet/MqttClientFactory.cs
+++ b/Source/MQTTnet/MqttClientFactory.cs
@@ -14,7 +14,7 @@ namespace MQTTnet;
 public class MqttClientFactory
 {
     readonly IMqttNetLogger _logger;
-    IMqttClientAdapterFactory _clientAdapterFactory;
+    readonly IMqttClientAdapterFactory _clientAdapterFactory;
 
     public IMqttNetLogger DefaultLogger => _logger;
 
@@ -121,10 +121,4 @@ public class MqttClientFactory
         return new MqttClientUnsubscribeOptionsBuilder();
     }
 
-    public MqttClientFactory UseClientAdapterFactory(IMqttClientAdapterFactory clientAdapterFactory)
-    {
-        ArgumentNullException.ThrowIfNull(clientAdapterFactory);
-        _clientAdapterFactory = clientAdapterFactory;
-        return this;
-    }
 }


### PR DESCRIPTION
1. Removed sealed modifier.
2. Added .ctor(IMqttNetLogger, IMqttClientAdapterFactory) to suit dependency injection
3. Removed UseClientAdapterFactory(IMqttClientAdapterFactory) method.
4. Fixed issue with CreateLowLevelMqttClient(IMqttClientAdapterFactory) not using parameters.