### PR TITLE
Added EndPoint RemoteEndPoint {get;} property to channel

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -61,21 +61,21 @@ public sealed class MqttConnectionContext : IMqttChannelAdapter
         }
     }
 
-    public string Endpoint
+    public EndPoint RemoteEndPoint
     {
         get
         {
             // mqtt over tcp
             if (_connection.RemoteEndPoint != null)
             {
-                return _connection.RemoteEndPoint.ToString();
+                return _connection.RemoteEndPoint;
             }
 
             // mqtt over websocket
             var httpFeature = _connection.Features.Get<IHttpConnectionFeature>();
             if (httpFeature?.RemoteIpAddress != null)
             {
-                return new IPEndPoint(httpFeature.RemoteIpAddress, httpFeature.RemotePort).ToString();
+                return new IPEndPoint(httpFeature.RemoteIpAddress, httpFeature.RemotePort);
             }
 
             return null;

--- a/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
@@ -15,6 +15,7 @@ using MQTTnet.Formatter.V3;
 using BenchmarkDotNet.Jobs;
 using MQTTnet.Diagnostics.Logger;
 using System.Buffers;
+using System.Net;
 
 namespace MQTTnet.Benchmarks
 {
@@ -76,7 +77,7 @@ namespace MQTTnet.Benchmarks
                 _position = _buffer.Offset;
             }
 
-            public string Endpoint { get; } = string.Empty;
+            public EndPoint RemoteEndPoint { get; set; }
 
             public bool IsSecureConnection { get; } = false;
 

--- a/Source/MQTTnet.Server/Events/ClientConnectedEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ClientConnectedEventArgs.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net;
 using MQTTnet.Formatter;
 using MQTTnet.Packets;
 
@@ -14,11 +15,11 @@ namespace MQTTnet.Server
     {
         readonly MqttConnectPacket _connectPacket;
 
-        public ClientConnectedEventArgs(MqttConnectPacket connectPacket, MqttProtocolVersion protocolVersion, string endpoint, IDictionary sessionItems)
+        public ClientConnectedEventArgs(MqttConnectPacket connectPacket, MqttProtocolVersion protocolVersion, EndPoint remoteEndPoint, IDictionary sessionItems)
         {
             _connectPacket = connectPacket ?? throw new ArgumentNullException(nameof(connectPacket));
             ProtocolVersion = protocolVersion;
-            Endpoint = endpoint;
+            RemoteEndPoint = remoteEndPoint;
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
         }
 
@@ -35,7 +36,10 @@ namespace MQTTnet.Server
         /// <summary>
         ///     Gets the endpoint of the connected client.
         /// </summary>
-        public string Endpoint { get; }
+        public EndPoint RemoteEndPoint { get; }
+
+        [Obsolete("Use RemoteEndPoint instead.")]
+        public string Endpoint => RemoteEndPoint?.ToString();
 
         /// <summary>
         ///     Gets the protocol version which is used by the connected client.

--- a/Source/MQTTnet.Server/Events/ClientDisconnectedEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ClientDisconnectedEventArgs.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
 
@@ -18,12 +19,12 @@ namespace MQTTnet.Server
             string clientId,
             MqttDisconnectPacket disconnectPacket,
             MqttClientDisconnectType disconnectType,
-            string endpoint,
+            EndPoint remoteEndPoint,
             IDictionary sessionItems)
         {
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
             DisconnectType = disconnectType;
-            Endpoint = endpoint;
+            RemoteEndPoint = remoteEndPoint;
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
 
             // The DISCONNECT packet can be null in case of a non clean disconnect or session takeover.
@@ -38,7 +39,10 @@ namespace MQTTnet.Server
 
         public MqttClientDisconnectType DisconnectType { get; }
 
-        public string Endpoint { get; }
+        public EndPoint RemoteEndPoint { get; }
+
+        [Obsolete("Use RemoteEndPoint instead.")]
+        public string Endpoint => RemoteEndPoint?.ToString();
 
         /// <summary>
         ///     Gets the reason code sent by the client.

--- a/Source/MQTTnet.Server/Events/InterceptingPacketEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/InterceptingPacketEventArgs.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.Net;
 using System.Threading;
 using MQTTnet.Packets;
 
@@ -11,11 +12,11 @@ namespace MQTTnet.Server
 {
     public sealed class InterceptingPacketEventArgs : EventArgs
     {
-        public InterceptingPacketEventArgs(CancellationToken cancellationToken, string clientId, string endpoint, MqttPacket packet, IDictionary sessionItems)
+        public InterceptingPacketEventArgs(CancellationToken cancellationToken, string clientId, EndPoint remoteEndPoint, MqttPacket packet, IDictionary sessionItems)
         {
             CancellationToken = cancellationToken;
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
-            Endpoint = endpoint;
+            RemoteEndPoint = remoteEndPoint;
             Packet = packet ?? throw new ArgumentNullException(nameof(packet));
             SessionItems = sessionItems;
         }
@@ -34,7 +35,10 @@ namespace MQTTnet.Server
         /// <summary>
         ///     Gets the endpoint of the sending or receiving client.
         /// </summary>
-        public string Endpoint { get; }
+        public EndPoint RemoteEndPoint { get; }
+
+        [Obsolete("Use RemoteEndPoint instead.")]
+        public string Endpoint => RemoteEndPoint?.ToString();
 
         /// <summary>
         ///     Gets or sets the MQTT packet which was received or will be sent.

--- a/Source/MQTTnet.Server/Events/ValidatingConnectionEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ValidatingConnectionEventArgs.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using MQTTnet.Adapter;
@@ -70,7 +71,10 @@ namespace MQTTnet.Server
         /// </summary>
         public string ClientId => _connectPacket.ClientId;
 
-        public string Endpoint => ChannelAdapter.Endpoint;
+        public EndPoint RemoteEndPoint => ChannelAdapter.RemoteEndPoint;
+
+        [Obsolete("Use RemoteEndPoint instead.")]
+        public string Endpoint => RemoteEndPoint?.ToString();
 
         public bool IsSecureConnection => ChannelAdapter.IsSecureConnection;
 

--- a/Source/MQTTnet.Server/Internal/Adapter/MqttTcpServerListener.cs
+++ b/Source/MQTTnet.Server/Internal/Adapter/MqttTcpServerListener.cs
@@ -167,11 +167,11 @@ namespace MQTTnet.Server.Internal.Adapter
         async Task TryHandleClientConnectionAsync(CrossPlatformSocket clientSocket)
         {
             Stream stream = null;
-            string remoteEndPoint = null;
+            EndPoint remoteEndPoint = null;
 
             try
             {
-                remoteEndPoint = clientSocket.RemoteEndPoint.ToString();
+                remoteEndPoint = clientSocket.RemoteEndPoint;
 
                 _logger.Verbose("TCP client '{0}' accepted (Local endpoint={1})", remoteEndPoint, _localEndPoint);
 

--- a/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
@@ -19,22 +19,18 @@ namespace MQTTnet.Server.Internal;
 public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification, IDisposable
 {
     readonly Dictionary<string, MqttConnectedClient> _clients = new(4096);
-
     readonly AsyncLock _createConnectionSyncRoot = new();
-
     readonly MqttServerEventContainer _eventContainer;
     readonly MqttNetSourceLogger _logger;
     readonly MqttServerOptions _options;
-
     readonly MqttRetainedMessagesManager _retainedMessagesManager;
     readonly IMqttNetLogger _rootLogger;
-
     readonly ReaderWriterLockSlim _sessionsManagementLock = new();
 
     // The _sessions dictionary contains all session, the _subscriberSessions hash set contains subscriber sessions only.
     // See the MqttSubscription object for a detailed explanation.
     readonly MqttSessionsStorage _sessionsStorage = new();
-    readonly HashSet<MqttSession> _subscriberSessions = new();
+    readonly HashSet<MqttSession> _subscriberSessions = [];
 
     public MqttClientSessionsManager(MqttServerOptions options, MqttRetainedMessagesManager retainedMessagesManager, MqttServerEventContainer eventContainer, IMqttNetLogger logger)
     {
@@ -365,7 +361,11 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
 
             if (_eventContainer.ClientConnectedEvent.HasHandlers)
             {
-                var eventArgs = new ClientConnectedEventArgs(connectPacket, channelAdapter.PacketFormatterAdapter.ProtocolVersion, channelAdapter.RemoteEndPoint, connectedClient.Session.Items);
+                var eventArgs = new ClientConnectedEventArgs(
+                    connectPacket,
+                    channelAdapter.PacketFormatterAdapter.ProtocolVersion,
+                    channelAdapter.RemoteEndPoint,
+                    connectedClient.Session.Items);
 
                 await _eventContainer.ClientConnectedEvent.TryInvokeAsync(eventArgs, _logger).ConfigureAwait(false);
             }
@@ -591,7 +591,12 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
 
                 if (_eventContainer.ClientDisconnectedEvent.HasHandlers)
                 {
-                    var eventArgs = new ClientDisconnectedEventArgs(oldConnectedClient.Id, null, MqttClientDisconnectType.Takeover, oldConnectedClient.RemoteEndPoint, oldConnectedClient.Session.Items);
+                    var eventArgs = new ClientDisconnectedEventArgs(
+                        oldConnectedClient.Id,
+                        null,
+                        MqttClientDisconnectType.Takeover,
+                        oldConnectedClient.RemoteEndPoint,
+                        oldConnectedClient.Session.Items);
 
                     await _eventContainer.ClientDisconnectedEvent.TryInvokeAsync(eventArgs, _logger).ConfigureAwait(false);
                 }
@@ -671,39 +676,39 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
         switch (connectedClient.ChannelAdapter.PacketFormatterAdapter.ProtocolVersion)
         {
             case MqttProtocolVersion.V500:
+            {
+                // MQTT 5.0 section 3.1.2.11.2
+                // The Client and Server MUST store the Session State after the Network Connection is closed if the Session Expiry Interval is greater than 0 [MQTT-3.1.2-23].
+                //
+                // A Client that only wants to process messages while connected will set the Clean Start to 1 and set the Session Expiry Interval to 0.
+                // It will not receive Application Messages published before it connected and has to subscribe afresh to any topics that it is interested
+                // in each time it connects.
+
+                var effectiveSessionExpiryInterval = connectedClient.DisconnectPacket?.SessionExpiryInterval ?? 0U;
+                if (effectiveSessionExpiryInterval == 0U)
                 {
-                    // MQTT 5.0 section 3.1.2.11.2
-                    // The Client and Server MUST store the Session State after the Network Connection is closed if the Session Expiry Interval is greater than 0 [MQTT-3.1.2-23].
-                    //
-                    // A Client that only wants to process messages while connected will set the Clean Start to 1 and set the Session Expiry Interval to 0.
-                    // It will not receive Application Messages published before it connected and has to subscribe afresh to any topics that it is interested
-                    // in each time it connects.
-
-                    var effectiveSessionExpiryInterval = connectedClient.DisconnectPacket?.SessionExpiryInterval ?? 0U;
-                    if (effectiveSessionExpiryInterval == 0U)
-                    {
-                        // From RFC: If the Session Expiry Interval is absent, the Session Expiry Interval in the CONNECT packet is used.
-                        effectiveSessionExpiryInterval = connectedClient.ConnectPacket.SessionExpiryInterval;
-                    }
-
-                    return effectiveSessionExpiryInterval != 0U;
+                    // From RFC: If the Session Expiry Interval is absent, the Session Expiry Interval in the CONNECT packet is used.
+                    effectiveSessionExpiryInterval = connectedClient.ConnectPacket.SessionExpiryInterval;
                 }
+
+                return effectiveSessionExpiryInterval != 0U;
+            }
 
             case MqttProtocolVersion.V311:
-                {
-                    // MQTT 3.1.1 section 3.1.2.4: persist only if 'not CleanSession'
-                    //
-                    // If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
-                    // This Session lasts as long as the Network Connection. State data associated with this Session MUST NOT be
-                    // reused in any subsequent Session [MQTT-3.1.2-6].
+            {
+                // MQTT 3.1.1 section 3.1.2.4: persist only if 'not CleanSession'
+                //
+                // If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
+                // This Session lasts as long as the Network Connection. State data associated with this Session MUST NOT be
+                // reused in any subsequent Session [MQTT-3.1.2-6].
 
-                    return !connectedClient.ConnectPacket.CleanSession;
-                }
+                return !connectedClient.ConnectPacket.CleanSession;
+            }
 
             case MqttProtocolVersion.V310:
-                {
-                    return true;
-                }
+            {
+                return true;
+            }
 
             default:
                 throw new NotSupportedException();

--- a/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
@@ -365,7 +365,7 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
 
             if (_eventContainer.ClientConnectedEvent.HasHandlers)
             {
-                var eventArgs = new ClientConnectedEventArgs(connectPacket, channelAdapter.PacketFormatterAdapter.ProtocolVersion, channelAdapter.Endpoint, connectedClient.Session.Items);
+                var eventArgs = new ClientConnectedEventArgs(connectPacket, channelAdapter.PacketFormatterAdapter.ProtocolVersion, channelAdapter.RemoteEndPoint, connectedClient.Session.Items);
 
                 await _eventContainer.ClientConnectedEvent.TryInvokeAsync(eventArgs, _logger).ConfigureAwait(false);
             }
@@ -403,7 +403,7 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
                     }
                 }
 
-                var endpoint = connectedClient.Endpoint;
+                var endpoint = connectedClient.RemoteEndPoint;
 
                 if (connectedClient.Id != null && !connectedClient.IsTakenOver && _eventContainer.ClientDisconnectedEvent.HasHandlers)
                 {
@@ -591,7 +591,7 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
 
                 if (_eventContainer.ClientDisconnectedEvent.HasHandlers)
                 {
-                    var eventArgs = new ClientDisconnectedEventArgs(oldConnectedClient.Id, null, MqttClientDisconnectType.Takeover, oldConnectedClient.Endpoint, oldConnectedClient.Session.Items);
+                    var eventArgs = new ClientDisconnectedEventArgs(oldConnectedClient.Id, null, MqttClientDisconnectType.Takeover, oldConnectedClient.RemoteEndPoint, oldConnectedClient.Session.Items);
 
                     await _eventContainer.ClientDisconnectedEvent.TryInvokeAsync(eventArgs, _logger).ConfigureAwait(false);
                 }
@@ -655,14 +655,14 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
         }
         catch (OperationCanceledException)
         {
-            _logger.Warning("Client '{0}': Connected but did not sent a CONNECT packet.", channelAdapter.Endpoint);
+            _logger.Warning("Client '{0}': Connected but did not sent a CONNECT packet.", channelAdapter.RemoteEndPoint);
         }
         catch (MqttCommunicationTimedOutException)
         {
-            _logger.Warning("Client '{0}': Connected but did not sent a CONNECT packet.", channelAdapter.Endpoint);
+            _logger.Warning("Client '{0}': Connected but did not sent a CONNECT packet.", channelAdapter.RemoteEndPoint);
         }
 
-        _logger.Warning("Client '{0}': First received packet was no 'CONNECT' packet [MQTT-3.1.0-1].", channelAdapter.Endpoint);
+        _logger.Warning("Client '{0}': First received packet was no 'CONNECT' packet [MQTT-3.1.0-1].", channelAdapter.RemoteEndPoint);
         return null;
     }
 
@@ -671,39 +671,39 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
         switch (connectedClient.ChannelAdapter.PacketFormatterAdapter.ProtocolVersion)
         {
             case MqttProtocolVersion.V500:
-            {
-                // MQTT 5.0 section 3.1.2.11.2
-                // The Client and Server MUST store the Session State after the Network Connection is closed if the Session Expiry Interval is greater than 0 [MQTT-3.1.2-23].
-                //
-                // A Client that only wants to process messages while connected will set the Clean Start to 1 and set the Session Expiry Interval to 0.
-                // It will not receive Application Messages published before it connected and has to subscribe afresh to any topics that it is interested
-                // in each time it connects.
-
-                var effectiveSessionExpiryInterval = connectedClient.DisconnectPacket?.SessionExpiryInterval ?? 0U;
-                if (effectiveSessionExpiryInterval == 0U)
                 {
-                    // From RFC: If the Session Expiry Interval is absent, the Session Expiry Interval in the CONNECT packet is used.
-                    effectiveSessionExpiryInterval = connectedClient.ConnectPacket.SessionExpiryInterval;
+                    // MQTT 5.0 section 3.1.2.11.2
+                    // The Client and Server MUST store the Session State after the Network Connection is closed if the Session Expiry Interval is greater than 0 [MQTT-3.1.2-23].
+                    //
+                    // A Client that only wants to process messages while connected will set the Clean Start to 1 and set the Session Expiry Interval to 0.
+                    // It will not receive Application Messages published before it connected and has to subscribe afresh to any topics that it is interested
+                    // in each time it connects.
+
+                    var effectiveSessionExpiryInterval = connectedClient.DisconnectPacket?.SessionExpiryInterval ?? 0U;
+                    if (effectiveSessionExpiryInterval == 0U)
+                    {
+                        // From RFC: If the Session Expiry Interval is absent, the Session Expiry Interval in the CONNECT packet is used.
+                        effectiveSessionExpiryInterval = connectedClient.ConnectPacket.SessionExpiryInterval;
+                    }
+
+                    return effectiveSessionExpiryInterval != 0U;
                 }
 
-                return effectiveSessionExpiryInterval != 0U;
-            }
-
             case MqttProtocolVersion.V311:
-            {
-                // MQTT 3.1.1 section 3.1.2.4: persist only if 'not CleanSession'
-                //
-                // If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
-                // This Session lasts as long as the Network Connection. State data associated with this Session MUST NOT be
-                // reused in any subsequent Session [MQTT-3.1.2-6].
+                {
+                    // MQTT 3.1.1 section 3.1.2.4: persist only if 'not CleanSession'
+                    //
+                    // If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
+                    // This Session lasts as long as the Network Connection. State data associated with this Session MUST NOT be
+                    // reused in any subsequent Session [MQTT-3.1.2-6].
 
-                return !connectedClient.ConnectPacket.CleanSession;
-            }
+                    return !connectedClient.ConnectPacket.CleanSession;
+                }
 
             case MqttProtocolVersion.V310:
-            {
-                return true;
-            }
+                {
+                    return true;
+                }
 
             default:
                 throw new NotSupportedException();

--- a/Source/MQTTnet.Server/Status/MqttClientStatus.cs
+++ b/Source/MQTTnet.Server/Status/MqttClientStatus.cs
@@ -4,6 +4,7 @@
 
 using MQTTnet.Formatter;
 using MQTTnet.Server.Internal;
+using System.Net;
 
 namespace MQTTnet.Server;
 
@@ -22,7 +23,10 @@ public sealed class MqttClientStatus
 
     public DateTime ConnectedTimestamp => _client.Statistics.ConnectedTimestamp;
 
-    public string Endpoint => _client.Endpoint;
+    public EndPoint RemoteEndPoint => _client.RemoteEndPoint;
+
+    [Obsolete("Use RemoteEndPoint instead.")]
+    public string Endpoint => RemoteEndPoint?.ToString();
 
     /// <summary>
     ///     Gets or sets the client identifier.

--- a/Source/MQTTnet.TestApp/ServerTest.cs
+++ b/Source/MQTTnet.TestApp/ServerTest.cs
@@ -43,7 +43,9 @@ namespace MQTTnet.TestApp
         {
             try
             {
-                var options = new MqttServerOptions();
+                var options = new MqttServerOptionsBuilder()
+                    .WithDefaultEndpoint()
+                    .Build();
 
                 // Extend the timestamp for all messages from clients.
                 // Protect several topics from being subscribed from every client.

--- a/Source/MQTTnet.Tests/Mockups/MemoryMqttChannel.cs
+++ b/Source/MQTTnet.Tests/Mockups/MemoryMqttChannel.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.AspNetCore.Http;
 using MQTTnet.Channel;
 using MQTTnet.Internal;
 using System.Buffers;
 using System.IO;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,7 +28,7 @@ namespace MQTTnet.Tests.Mockups
             _stream = new MemoryStream(buffer);
         }
 
-        public string Endpoint { get; } = "<Test channel>";
+        public EndPoint RemoteEndPoint { get; set; }
 
         public bool IsSecureConnection { get; } = false;
 

--- a/Source/MQTTnet.Tests/MqttTcpChannel_Tests.cs
+++ b/Source/MQTTnet.Tests/MqttTcpChannel_Tests.cs
@@ -40,10 +40,11 @@ public class MqttTcpChannel_Tests
                 },
                 ct.Token);
 
+            var remoteEndPoint = new DnsEndPoint("localhost", 50001);
             using var clientSocket = new CrossPlatformSocket(AddressFamily.InterNetwork, ProtocolType.Tcp);
-            await clientSocket.ConnectAsync(new DnsEndPoint("localhost", 50001), CancellationToken.None);
+            await clientSocket.ConnectAsync(remoteEndPoint, CancellationToken.None);
 
-            var tcpChannel = new MqttTcpChannel(clientSocket.GetStream(), "test", null);
+            var tcpChannel = new MqttTcpChannel(clientSocket.GetStream(), remoteEndPoint, null);
 
             await Task.Delay(100, ct.Token);
 

--- a/Source/MQTTnet.Tests/Server/Events_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Events_Tests.cs
@@ -36,7 +36,7 @@ namespace MQTTnet.Tests.Server
                 Assert.IsNotNull(eventArgs);
 
                 Assert.IsTrue(eventArgs.ClientId.StartsWith(nameof(Fire_Client_Connected_Event)));
-                Assert.IsTrue(eventArgs.Endpoint.Contains("127.0.0.1"));
+                Assert.IsTrue(eventArgs.RemoteEndPoint.ToString().Contains("127.0.0.1"));
                 Assert.AreEqual(MqttProtocolVersion.V311, eventArgs.ProtocolVersion);
                 Assert.AreEqual("TheUser", eventArgs.UserName);
             }
@@ -64,7 +64,7 @@ namespace MQTTnet.Tests.Server
                 Assert.IsNotNull(eventArgs);
 
                 Assert.IsTrue(eventArgs.ClientId.StartsWith(nameof(Fire_Client_Disconnected_Event)));
-                Assert.IsTrue(eventArgs.Endpoint.Contains("127.0.0.1"));
+                Assert.IsTrue(eventArgs.RemoteEndPoint.ToString().Contains("127.0.0.1"));
                 Assert.AreEqual(MqttClientDisconnectType.Clean, eventArgs.DisconnectType);
             }
         }

--- a/Source/MQTTnet/Adapter/IMqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/IMqttChannelAdapter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,8 @@ public interface IMqttChannelAdapter : IDisposable
     long BytesSent { get; }
 
     X509Certificate2 ClientCertificate { get; }
-    string Endpoint { get; }
+
+    EndPoint RemoteEndPoint { get; }
 
     bool IsSecureConnection { get; }
 

--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Buffers;
 using System.IO;
+using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
@@ -51,7 +52,7 @@ public sealed class MqttChannelAdapter : Disposable, IMqttChannelAdapter
 
     public X509Certificate2 ClientCertificate => _channel.ClientCertificate;
 
-    public string Endpoint => _channel.Endpoint;
+    public EndPoint RemoteEndPoint => _channel.RemoteEndPoint;
 
     public bool IsSecureConnection => _channel.IsSecureConnection;
 

--- a/Source/MQTTnet/Channel/IMqttChannel.cs
+++ b/Source/MQTTnet/Channel/IMqttChannel.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Buffers;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace MQTTnet.Channel;
 public interface IMqttChannel : IDisposable
 {
     X509Certificate2 ClientCertificate { get; }
-    string Endpoint { get; }
+    EndPoint RemoteEndPoint { get; }
 
     bool IsSecureConnection { get; }
 

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -37,11 +37,11 @@ namespace MQTTnet.Implementations
             IsSecureConnection = clientOptions.ChannelOptions?.TlsOptions?.UseTls == true;
         }
 
-        public MqttTcpChannel(Stream stream, string endpoint, X509Certificate2 clientCertificate) : this()
+        public MqttTcpChannel(Stream stream, EndPoint remoteEndPoint, X509Certificate2 clientCertificate) : this()
         {
             _stream = stream ?? throw new ArgumentNullException(nameof(stream));
 
-            Endpoint = endpoint;
+            RemoteEndPoint = remoteEndPoint;
 
             IsSecureConnection = stream is SslStream;
             ClientCertificate = clientCertificate;
@@ -49,7 +49,7 @@ namespace MQTTnet.Implementations
 
         public X509Certificate2 ClientCertificate { get; }
 
-        public string Endpoint { get; private set; }
+        public EndPoint RemoteEndPoint { get; private set; }
 
         public bool IsSecureConnection { get; }
 
@@ -175,7 +175,7 @@ namespace MQTTnet.Implementations
                     _stream = networkStream;
                 }
 
-                Endpoint = socket.RemoteEndPoint?.ToString();
+                RemoteEndPoint = socket.RemoteEndPoint;
             }
             catch (Exception)
             {

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -26,18 +26,18 @@ namespace MQTTnet.Implementations
             _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
-        public MqttWebSocketChannel(WebSocket webSocket, string endpoint, bool isSecureConnection, X509Certificate2 clientCertificate)
+        public MqttWebSocketChannel(WebSocket webSocket, EndPoint remoteEndPoint, bool isSecureConnection, X509Certificate2 clientCertificate)
         {
             _webSocket = webSocket ?? throw new ArgumentNullException(nameof(webSocket));
 
-            Endpoint = endpoint;
+            RemoteEndPoint = remoteEndPoint;
             IsSecureConnection = isSecureConnection;
             ClientCertificate = clientCertificate;
         }
 
         public X509Certificate2 ClientCertificate { get; }
 
-        public string Endpoint { get; }
+        public EndPoint RemoteEndPoint { get; }
 
         public bool IsSecureConnection { get; private set; }
 


### PR DESCRIPTION

Each internal channel only retains the `EndPoint RemoteEndPoint {get;}` property, 
and the external event parameter type still retains the `string Endpoint {get;}` property.

```c#
public EndPoint RemoteEndPoint { get; }

[Obsolete("Use RemoteEndPoint instead.")]
public string Endpoint => RemoteEndPoint?.ToString();
```