### PR TITLE
Cannot set any properties of tcpOptions when with WebSocketServer.

### DIFF
--- a/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
@@ -153,15 +153,11 @@ public sealed class MqttClientOptionsBuilder
 
             case "ws":
                 WithWebSocketServer(o => o.WithUri(uri.ToString()))
-                    .WithAddressFamily(AddressFamily.Unspecified)
-                    .WithProtocolType(ProtocolType.Tcp)
                     .WithTlsOptions(o => o.UseTls(false));
                 break;
 
             case "wss":
                 WithWebSocketServer(o => o.WithUri(uri.ToString()))
-                    .WithAddressFamily(AddressFamily.Unspecified)
-                    .WithProtocolType(ProtocolType.Tcp)
                     .WithTlsOptions(o => o.UseTls(true));
                 break;
 


### PR DESCRIPTION
I introduced a websocket related bug when implementing #2107, this PR is to fix it.