### PR TITLE
Replace all _DataTestMethod_

### DIFF
--- a/Source/MQTTnet.Benchmarks/MQTTnet.Benchmarks.csproj
+++ b/Source/MQTTnet.Benchmarks/MQTTnet.Benchmarks.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.12"/>
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
@@ -27,7 +27,7 @@ namespace MQTTnet.Tests.Clients.MqttClient
     [TestClass]
     public sealed class MqttClient_Tests : BaseTestClass
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(MqttQualityOfServiceLevel.ExactlyOnce)]
         [DataRow(MqttQualityOfServiceLevel.AtMostOnce)]
         [DataRow(MqttQualityOfServiceLevel.AtLeastOnce)]

--- a/Source/MQTTnet.Tests/MQTTnet.Tests.csproj
+++ b/Source/MQTTnet.Tests/MQTTnet.Tests.csproj
@@ -16,9 +16,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 

--- a/Source/MQTTnet.Tests/Server/Session_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Session_Tests.cs
@@ -182,7 +182,7 @@ namespace MQTTnet.Tests.Server
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(MqttQualityOfServiceLevel.ExactlyOnce)]
         [DataRow(MqttQualityOfServiceLevel.AtLeastOnce)]
         public async Task Retry_If_Not_PubAck(MqttQualityOfServiceLevel qos)

--- a/Source/MQTTnet.Tests/Server/Subscribe_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Subscribe_Tests.cs
@@ -20,7 +20,7 @@ namespace MQTTnet.Tests.Server
     [TestClass]
     public sealed class Subscribe_Tests : BaseTestClass
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("A", "A", true)]
         [DataRow("A", "B", false)]
         [DataRow("A", "#", true)]


### PR DESCRIPTION
This PR replaces all _DataTestMethod_ with _TestMethod_ because _DataTestMethod_ is obsolete.
It also updates all testing nugets.