### PR TITLE
Added UserName property to various Server EventArgs.

### DIFF
--- a/Source/MQTTnet.Server/Events/ClientAcknowledgedPublishPacketEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ClientAcknowledgedPublishPacketEventArgs.cs
@@ -10,9 +10,10 @@ namespace MQTTnet.Server
 {
     public sealed class ClientAcknowledgedPublishPacketEventArgs : EventArgs
     {
-        public ClientAcknowledgedPublishPacketEventArgs(string clientId, IDictionary sessionItems, MqttPublishPacket publishPacket, MqttPacketWithIdentifier acknowledgePacket)
+        public ClientAcknowledgedPublishPacketEventArgs(string clientId, string userName, IDictionary sessionItems, MqttPublishPacket publishPacket, MqttPacketWithIdentifier acknowledgePacket)
         {
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            UserName = userName;
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
             PublishPacket = publishPacket ?? throw new ArgumentNullException(nameof(publishPacket));
             AcknowledgePacket = acknowledgePacket ?? throw new ArgumentNullException(nameof(acknowledgePacket));
@@ -27,6 +28,11 @@ namespace MQTTnet.Server
         ///     Gets the ID of the client which acknowledged a PUBLISH packet.
         /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the user name of the client.
+        /// </summary>
+        public string UserName { get; }
 
         /// <summary>
         ///     Gets whether the PUBLISH packet is fully acknowledged. This is the case for PUBACK (QoS 1) and PUBCOMP (QoS 2.

--- a/Source/MQTTnet.Server/Events/ClientConnectedEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ClientConnectedEventArgs.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
+using System.Text;
 using MQTTnet.Formatter;
 using MQTTnet.Packets;
 
@@ -55,6 +56,11 @@ namespace MQTTnet.Server
         ///     Gets the user name of the connected client.
         /// </summary>
         public string UserName => _connectPacket.Username;
+
+        /// <summary>
+        ///     Gets the password of the connected client.
+        /// </summary>
+        public string Password => Encoding.UTF8.GetString(_connectPacket.Password.AsSpan());
 
         /// <summary>
         ///     Gets the user properties sent by the client.

--- a/Source/MQTTnet.Server/Events/ClientDisconnectedEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ClientDisconnectedEventArgs.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
+using System.Text;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
 
@@ -13,20 +14,21 @@ namespace MQTTnet.Server
 {
     public sealed class ClientDisconnectedEventArgs : EventArgs
     {
+        readonly MqttConnectPacket _connectPacket;
         readonly MqttDisconnectPacket _disconnectPacket;
 
         public ClientDisconnectedEventArgs(
-            string clientId,
+            MqttConnectPacket connectPacket,
             MqttDisconnectPacket disconnectPacket,
             MqttClientDisconnectType disconnectType,
             EndPoint remoteEndPoint,
             IDictionary sessionItems)
         {
-            ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
             DisconnectType = disconnectType;
             RemoteEndPoint = remoteEndPoint;
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
 
+            _connectPacket = connectPacket;
             // The DISCONNECT packet can be null in case of a non clean disconnect or session takeover.
             _disconnectPacket = disconnectPacket;
         }
@@ -35,7 +37,17 @@ namespace MQTTnet.Server
         ///     Gets the client identifier.
         ///     Hint: This identifier needs to be unique over all used clients / devices on the broker to avoid connection issues.
         /// </summary>
-        public string ClientId { get; }
+        public string ClientId => _connectPacket.ClientId;
+
+        /// <summary>
+        ///     Gets the user name of the client.
+        /// </summary>
+        public string UserName => _connectPacket.Username;
+
+        /// <summary>
+        ///     Gets the password of the client.
+        /// </summary>
+        public string Password => Encoding.UTF8.GetString(_connectPacket.Password.AsSpan());
 
         public MqttClientDisconnectType DisconnectType { get; }
 

--- a/Source/MQTTnet.Server/Events/ClientSubscribedTopicEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ClientSubscribedTopicEventArgs.cs
@@ -10,9 +10,10 @@ namespace MQTTnet.Server
 {
     public sealed class ClientSubscribedTopicEventArgs : EventArgs
     {
-        public ClientSubscribedTopicEventArgs(string clientId, MqttTopicFilter topicFilter, IDictionary sessionItems)
+        public ClientSubscribedTopicEventArgs(string clientId, string userName, MqttTopicFilter topicFilter, IDictionary sessionItems)
         {
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            UserName = userName;
             TopicFilter = topicFilter ?? throw new ArgumentNullException(nameof(topicFilter));
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
         }
@@ -22,6 +23,11 @@ namespace MQTTnet.Server
         ///     Hint: This identifier needs to be unique over all used clients / devices on the broker to avoid connection issues.
         /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the user name of the client.
+        /// </summary>
+        public string UserName { get; }
 
         /// <summary>
         ///     Gets or sets a key/value collection that can be used to share data within the scope of this session.

--- a/Source/MQTTnet.Server/Events/ClientUnsubscribedTopicEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ClientUnsubscribedTopicEventArgs.cs
@@ -9,9 +9,10 @@ namespace MQTTnet.Server
 {
     public sealed class ClientUnsubscribedTopicEventArgs : EventArgs
     {
-        public ClientUnsubscribedTopicEventArgs(string clientId, string topicFilter, IDictionary sessionItems)
+        public ClientUnsubscribedTopicEventArgs(string clientId, string userName, string topicFilter, IDictionary sessionItems)
         {
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            UserName = userName;
             TopicFilter = topicFilter ?? throw new ArgumentNullException(nameof(topicFilter));
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
         }
@@ -21,6 +22,11 @@ namespace MQTTnet.Server
         ///     Hint: This identifier needs to be unique over all used clients / devices on the broker to avoid connection issues.
         /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the user name of the client.
+        /// </summary>
+        public string UserName { get; }
 
         /// <summary>
         ///     Gets or sets a key/value collection that can be used to share data within the scope of this session.

--- a/Source/MQTTnet.Server/Events/InterceptingPacketEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/InterceptingPacketEventArgs.cs
@@ -12,10 +12,11 @@ namespace MQTTnet.Server
 {
     public sealed class InterceptingPacketEventArgs : EventArgs
     {
-        public InterceptingPacketEventArgs(CancellationToken cancellationToken, string clientId, EndPoint remoteEndPoint, MqttPacket packet, IDictionary sessionItems)
+        public InterceptingPacketEventArgs(CancellationToken cancellationToken, string clientId, string userName, EndPoint remoteEndPoint, MqttPacket packet, IDictionary sessionItems)
         {
             CancellationToken = cancellationToken;
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            UserName = userName;
             RemoteEndPoint = remoteEndPoint;
             Packet = packet ?? throw new ArgumentNullException(nameof(packet));
             SessionItems = sessionItems;
@@ -31,6 +32,11 @@ namespace MQTTnet.Server
         ///     Gets the client ID which has sent the packet or will receive the packet.
         /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the user name of the client.
+        /// </summary>
+        public string UserName { get; }
 
         /// <summary>
         ///     Gets the endpoint of the sending or receiving client.

--- a/Source/MQTTnet.Server/Events/InterceptingPublishEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/InterceptingPublishEventArgs.cs
@@ -10,11 +10,12 @@ namespace MQTTnet.Server
 {
     public sealed class InterceptingPublishEventArgs : EventArgs
     {
-        public InterceptingPublishEventArgs(MqttApplicationMessage applicationMessage, CancellationToken cancellationToken, string clientId, IDictionary sessionItems)
+        public InterceptingPublishEventArgs(MqttApplicationMessage applicationMessage, CancellationToken cancellationToken, string clientId, string userName, IDictionary sessionItems)
         {
             ApplicationMessage = applicationMessage ?? throw new ArgumentNullException(nameof(applicationMessage));
             CancellationToken = cancellationToken;
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            UserName = userName;
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
         }
 
@@ -30,6 +31,11 @@ namespace MQTTnet.Server
         ///     Hint: This identifier needs to be unique over all used clients / devices on the broker to avoid connection issues.
         /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the user name of the client.
+        /// </summary>
+        public string UserName { get; }
 
         public bool CloseConnection { get; set; }
 

--- a/Source/MQTTnet.Server/Events/InterceptingSubscriptionEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/InterceptingSubscriptionEventArgs.cs
@@ -15,12 +15,14 @@ namespace MQTTnet.Server
         public InterceptingSubscriptionEventArgs(
             CancellationToken cancellationToken,
             string clientId,
+            string userName,
             MqttSessionStatus session,
             MqttTopicFilter topicFilter,
             List<MqttUserProperty> userProperties)
         {
             CancellationToken = cancellationToken;
             ClientId = clientId;
+            UserName = userName;
             Session = session;
             TopicFilter = topicFilter;
             UserProperties = userProperties;
@@ -36,6 +38,11 @@ namespace MQTTnet.Server
         ///     Hint: This identifier needs to be unique over all used clients / devices on the broker to avoid connection issues.
         /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the user name of the client.
+        /// </summary>
+        public string UserName { get; }
 
         /// <summary>
         ///     Gets or sets whether the broker should close the client connection.

--- a/Source/MQTTnet.Server/Events/InterceptingUnsubscriptionEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/InterceptingUnsubscriptionEventArgs.cs
@@ -12,10 +12,11 @@ namespace MQTTnet.Server
 {
     public sealed class InterceptingUnsubscriptionEventArgs : EventArgs
     {
-        public InterceptingUnsubscriptionEventArgs(CancellationToken cancellationToken, string clientId, IDictionary sessionItems, string topic, List<MqttUserProperty> userProperties)
+        public InterceptingUnsubscriptionEventArgs(CancellationToken cancellationToken, string clientId, string userName, IDictionary sessionItems, string topic, List<MqttUserProperty> userProperties)
         {
             CancellationToken = cancellationToken;
             ClientId = clientId;
+            UserName = userName;
             SessionItems = sessionItems;
             Topic = topic;
             UserProperties = userProperties;
@@ -31,6 +32,11 @@ namespace MQTTnet.Server
         ///     Hint: This identifier needs to be unique over all used clients / devices on the broker to avoid connection issues.
         /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the user name of the client.
+        /// </summary>
+        public string UserName { get; } 
 
         /// <summary>
         ///     Gets or sets whether the broker should close the client connection.

--- a/Source/MQTTnet.Server/Events/SessionDeletedEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/SessionDeletedEventArgs.cs
@@ -9,9 +9,10 @@ namespace MQTTnet.Server
 {
     public sealed class SessionDeletedEventArgs : EventArgs
     {
-        public SessionDeletedEventArgs(string id, IDictionary sessionItems)
+        public SessionDeletedEventArgs(string id, string userName, IDictionary sessionItems)
         {
             Id = id ?? throw new ArgumentNullException(nameof(id));
+            UserName = userName;
             SessionItems = sessionItems ?? throw new ArgumentNullException(nameof(sessionItems));
         }
 
@@ -19,6 +20,11 @@ namespace MQTTnet.Server
         ///     Gets the ID of the session.
         /// </summary>
         public string Id { get; }
+
+        /// <summary>
+        /// Gets the user name of the session.
+        /// </summary>
+        public string UserName { get; }
 
         /// <summary>
         ///     Gets or sets a key/value collection that can be used to share data within the scope of this session.

--- a/Source/MQTTnet.Server/InjectedMqttApplicationMessage.cs
+++ b/Source/MQTTnet.Server/InjectedMqttApplicationMessage.cs
@@ -23,4 +23,6 @@ public sealed class InjectedMqttApplicationMessage
     public IDictionary CustomSessionItems { get; set; }
 
     public string SenderClientId { get; set; } = string.Empty;
+
+    public string SenderUserName { get; set; }
 }

--- a/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
@@ -409,7 +409,12 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
                 if (connectedClient.Id != null && !connectedClient.IsTakenOver && _eventContainer.ClientDisconnectedEvent.HasHandlers)
                 {
                     var disconnectType = connectedClient.DisconnectPacket != null ? MqttClientDisconnectType.Clean : MqttClientDisconnectType.NotClean;
-                    var eventArgs = new ClientDisconnectedEventArgs(connectedClient.ConnectPacket, connectedClient.DisconnectPacket, disconnectType, endpoint, connectedClient.Session.Items);
+                    var eventArgs = new ClientDisconnectedEventArgs(
+                        connectedClient.ConnectPacket,
+                        connectedClient.DisconnectPacket,
+                        disconnectType,
+                        endpoint,
+                        connectedClient.Session.Items);
 
                     await _eventContainer.ClientDisconnectedEvent.InvokeAsync(eventArgs).ConfigureAwait(false);
                 }
@@ -677,39 +682,39 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
         switch (connectedClient.ChannelAdapter.PacketFormatterAdapter.ProtocolVersion)
         {
             case MqttProtocolVersion.V500:
+            {
+                // MQTT 5.0 section 3.1.2.11.2
+                // The Client and Server MUST store the Session State after the Network Connection is closed if the Session Expiry Interval is greater than 0 [MQTT-3.1.2-23].
+                //
+                // A Client that only wants to process messages while connected will set the Clean Start to 1 and set the Session Expiry Interval to 0.
+                // It will not receive Application Messages published before it connected and has to subscribe afresh to any topics that it is interested
+                // in each time it connects.
+
+                var effectiveSessionExpiryInterval = connectedClient.DisconnectPacket?.SessionExpiryInterval ?? 0U;
+                if (effectiveSessionExpiryInterval == 0U)
                 {
-                    // MQTT 5.0 section 3.1.2.11.2
-                    // The Client and Server MUST store the Session State after the Network Connection is closed if the Session Expiry Interval is greater than 0 [MQTT-3.1.2-23].
-                    //
-                    // A Client that only wants to process messages while connected will set the Clean Start to 1 and set the Session Expiry Interval to 0.
-                    // It will not receive Application Messages published before it connected and has to subscribe afresh to any topics that it is interested
-                    // in each time it connects.
-
-                    var effectiveSessionExpiryInterval = connectedClient.DisconnectPacket?.SessionExpiryInterval ?? 0U;
-                    if (effectiveSessionExpiryInterval == 0U)
-                    {
-                        // From RFC: If the Session Expiry Interval is absent, the Session Expiry Interval in the CONNECT packet is used.
-                        effectiveSessionExpiryInterval = connectedClient.ConnectPacket.SessionExpiryInterval;
-                    }
-
-                    return effectiveSessionExpiryInterval != 0U;
+                    // From RFC: If the Session Expiry Interval is absent, the Session Expiry Interval in the CONNECT packet is used.
+                    effectiveSessionExpiryInterval = connectedClient.ConnectPacket.SessionExpiryInterval;
                 }
+
+                return effectiveSessionExpiryInterval != 0U;
+            }
 
             case MqttProtocolVersion.V311:
-                {
-                    // MQTT 3.1.1 section 3.1.2.4: persist only if 'not CleanSession'
-                    //
-                    // If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
-                    // This Session lasts as long as the Network Connection. State data associated with this Session MUST NOT be
-                    // reused in any subsequent Session [MQTT-3.1.2-6].
+            {
+                // MQTT 3.1.1 section 3.1.2.4: persist only if 'not CleanSession'
+                //
+                // If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
+                // This Session lasts as long as the Network Connection. State data associated with this Session MUST NOT be
+                // reused in any subsequent Session [MQTT-3.1.2-6].
 
-                    return !connectedClient.ConnectPacket.CleanSession;
-                }
+                return !connectedClient.ConnectPacket.CleanSession;
+            }
 
             case MqttProtocolVersion.V310:
-                {
-                    return true;
-                }
+            {
+                return true;
+            }
 
             default:
                 throw new NotSupportedException();

--- a/Source/MQTTnet.Server/Internal/MqttClientSubscriptionsManager.cs
+++ b/Source/MQTTnet.Server/Internal/MqttClientSubscriptionsManager.cs
@@ -209,7 +209,7 @@ namespace MQTTnet.Server.Internal
             {
                 foreach (var finalTopicFilter in finalTopicFilters)
                 {
-                    var eventArgs = new ClientSubscribedTopicEventArgs(_session.Id, finalTopicFilter, _session.Items);
+                    var eventArgs = new ClientSubscribedTopicEventArgs(_session.Id, _session.UserName, finalTopicFilter, _session.Items);
                     await _eventContainer.ClientSubscribedTopicEvent.InvokeAsync(eventArgs).ConfigureAwait(false);
                 }
             }
@@ -297,7 +297,7 @@ namespace MQTTnet.Server.Internal
             {
                 foreach (var topicFilter in unsubscribePacket.TopicFilters)
                 {
-                    var eventArgs = new ClientUnsubscribedTopicEventArgs(_session.Id, topicFilter, _session.Items);
+                    var eventArgs = new ClientUnsubscribedTopicEventArgs(_session.Id, _session.UserName, topicFilter, _session.Items);
                     await _eventContainer.ClientUnsubscribedTopicEvent.InvokeAsync(eventArgs).ConfigureAwait(false);
                 }
             }
@@ -460,7 +460,7 @@ namespace MQTTnet.Server.Internal
             List<MqttUserProperty> userProperties,
             CancellationToken cancellationToken)
         {
-            var eventArgs = new InterceptingSubscriptionEventArgs(cancellationToken, _session.Id, new MqttSessionStatus(_session), topicFilter, userProperties);
+            var eventArgs = new InterceptingSubscriptionEventArgs(cancellationToken, _session.Id, _session.UserName, new MqttSessionStatus(_session), topicFilter, userProperties);
 
             if (topicFilter.QualityOfServiceLevel == MqttQualityOfServiceLevel.AtMostOnce)
             {
@@ -493,7 +493,7 @@ namespace MQTTnet.Server.Internal
             List<MqttUserProperty> userProperties,
             CancellationToken cancellationToken)
         {
-            var clientUnsubscribingTopicEventArgs = new InterceptingUnsubscriptionEventArgs(cancellationToken, _session.Id, _session.Items, topicFilter, userProperties)
+            var clientUnsubscribingTopicEventArgs = new InterceptingUnsubscriptionEventArgs(cancellationToken, _session.Id, _session.UserName, _session.Items, topicFilter, userProperties)
             {
                 Response =
                 {

--- a/Source/MQTTnet.Server/Internal/MqttSession.cs
+++ b/Source/MQTTnet.Server/Internal/MqttSession.cs
@@ -53,6 +53,8 @@ public sealed class MqttSession : IDisposable
 
     public string Id => _connectPacket.ClientId;
 
+    public string UserName => _connectPacket.Username;
+
     public IDictionary Items { get; }
 
     public MqttConnectPacket LatestConnectPacket { get; set; }

--- a/Source/MQTTnet.Server/MqttServer.cs
+++ b/Source/MQTTnet.Server/MqttServer.cs
@@ -255,6 +255,7 @@ public class MqttServer : Disposable
 
         return _clientSessionsManager.DispatchApplicationMessage(
             injectedApplicationMessage.SenderClientId,
+            senderUserName: null,
             sessionItems,
             injectedApplicationMessage.ApplicationMessage,
             cancellationToken);

--- a/Source/MQTTnet.Server/MqttServer.cs
+++ b/Source/MQTTnet.Server/MqttServer.cs
@@ -255,7 +255,7 @@ public class MqttServer : Disposable
 
         return _clientSessionsManager.DispatchApplicationMessage(
             injectedApplicationMessage.SenderClientId,
-            senderUserName: null,
+            injectedApplicationMessage.SenderUserName,
             sessionItems,
             injectedApplicationMessage.ApplicationMessage,
             cancellationToken);

--- a/Source/MQTTnet.Tests/Server/Events_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Events_Tests.cs
@@ -29,7 +29,7 @@ namespace MQTTnet.Tests.Server
                     return CompletedTask.Instance;
                 };
 
-                await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser"));
+                await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser", "ThePassword"));
 
                 await LongTestDelay();
 
@@ -39,6 +39,7 @@ namespace MQTTnet.Tests.Server
                 Assert.IsTrue(eventArgs.RemoteEndPoint.ToString().Contains("127.0.0.1"));
                 Assert.AreEqual(MqttProtocolVersion.V311, eventArgs.ProtocolVersion);
                 Assert.AreEqual("TheUser", eventArgs.UserName);
+                Assert.AreEqual("ThePassword", eventArgs.Password);
             }
         }
 
@@ -56,7 +57,7 @@ namespace MQTTnet.Tests.Server
                     return CompletedTask.Instance;
                 };
 
-                var client = await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser"));
+                var client = await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser", "ThePassword"));
                 await client.DisconnectAsync();
 
                 await LongTestDelay();
@@ -66,6 +67,9 @@ namespace MQTTnet.Tests.Server
                 Assert.IsTrue(eventArgs.ClientId.StartsWith(nameof(Fire_Client_Disconnected_Event)));
                 Assert.IsTrue(eventArgs.RemoteEndPoint.ToString().Contains("127.0.0.1"));
                 Assert.AreEqual(MqttClientDisconnectType.Clean, eventArgs.DisconnectType);
+
+                Assert.AreEqual("TheUser", eventArgs.UserName);
+                Assert.AreEqual("ThePassword", eventArgs.Password);
             }
         }
 
@@ -83,7 +87,7 @@ namespace MQTTnet.Tests.Server
                     return CompletedTask.Instance;
                 };
 
-                var client = await testEnvironment.ConnectClient();
+                var client = await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser"));
                 await client.SubscribeAsync("The/Topic", MqttQualityOfServiceLevel.AtLeastOnce);
 
                 await LongTestDelay();
@@ -93,6 +97,7 @@ namespace MQTTnet.Tests.Server
                 Assert.IsTrue(eventArgs.ClientId.StartsWith(nameof(Fire_Client_Subscribed_Event)));
                 Assert.AreEqual("The/Topic", eventArgs.TopicFilter.Topic);
                 Assert.AreEqual(MqttQualityOfServiceLevel.AtLeastOnce, eventArgs.TopicFilter.QualityOfServiceLevel);
+                Assert.AreEqual("TheUser", eventArgs.UserName);
             }
         }
 
@@ -110,7 +115,7 @@ namespace MQTTnet.Tests.Server
                     return CompletedTask.Instance;
                 };
 
-                var client = await testEnvironment.ConnectClient();
+                var client = await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser"));
                 await client.UnsubscribeAsync("The/Topic");
 
                 await LongTestDelay();
@@ -119,6 +124,7 @@ namespace MQTTnet.Tests.Server
 
                 Assert.IsTrue(eventArgs.ClientId.StartsWith(nameof(Fire_Client_Unsubscribed_Event)));
                 Assert.AreEqual("The/Topic", eventArgs.TopicFilter);
+                Assert.AreEqual("TheUser", eventArgs.UserName);
             }
         }
 
@@ -136,7 +142,7 @@ namespace MQTTnet.Tests.Server
                     return CompletedTask.Instance;
                 };
 
-                var client = await testEnvironment.ConnectClient();
+                var client = await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser"));
                 await client.PublishStringAsync("The_Topic", "The_Payload");
 
                 await LongTestDelay();
@@ -146,6 +152,7 @@ namespace MQTTnet.Tests.Server
                 Assert.IsTrue(eventArgs.ClientId.StartsWith(nameof(Fire_Application_Message_Received_Event)));
                 Assert.AreEqual("The_Topic", eventArgs.ApplicationMessage.Topic);
                 Assert.AreEqual("The_Payload", eventArgs.ApplicationMessage.ConvertPayloadToString());
+                Assert.AreEqual("TheUser", eventArgs.UserName);
             }
         }
 


### PR DESCRIPTION
In server events, directly carrying the client's UserName may bring some convenience to upper-level developers, and adding the UserName will not cause any computing overhead.