### PR TITLE
Added AllowPacketFragmentationSelector option.

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionContext.cs
@@ -104,6 +104,15 @@ public sealed class MqttConnectionContext : IMqttChannelAdapter
         }
     }
 
+    public bool IsWebSocketConnection
+    {
+        get
+        {
+            var httpFeature = _connection.Features.Get<IHttpContextFeature>();
+            return httpFeature != null && httpFeature.HttpContext != null && httpFeature.HttpContext.WebSockets.IsWebSocketRequest;
+        }
+    }
+
     public MqttPacketFormatterAdapter PacketFormatterAdapter { get; }
 
     public async Task ConnectAsync(CancellationToken cancellationToken)

--- a/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
+++ b/Source/MQTTnet.Benchmarks/SerializerBenchmark.cs
@@ -83,6 +83,8 @@ namespace MQTTnet.Benchmarks
 
             public X509Certificate2 ClientCertificate { get; }
 
+            public bool IsWebSocketConnection => false;
+
             public void Reset()
             {
                 _position = _buffer.Offset;

--- a/Source/MQTTnet.Server/Events/ValidatingConnectionEventArgs.cs
+++ b/Source/MQTTnet.Server/Events/ValidatingConnectionEventArgs.cs
@@ -78,6 +78,8 @@ namespace MQTTnet.Server
 
         public bool IsSecureConnection => ChannelAdapter.IsSecureConnection;
 
+        public bool IsWebSocketConnection => ChannelAdapter.IsWebSocketConnection;
+
         /// <summary>
         ///     Gets or sets the keep alive period.
         ///     The connection is normally left open by the client so that is can send and receive data at any time.

--- a/Source/MQTTnet.Server/Internal/Adapter/MqttTcpServerListener.cs
+++ b/Source/MQTTnet.Server/Internal/Adapter/MqttTcpServerListener.cs
@@ -218,7 +218,14 @@ namespace MQTTnet.Server.Internal.Adapter
 
                     using (var clientAdapter = new MqttChannelAdapter(tcpChannel, packetFormatterAdapter, _rootLogger))
                     {
-                        clientAdapter.AllowPacketFragmentation = _options.AllowPacketFragmentation;
+                        if (_options.AllowPacketFragmentationSelector == null)
+                        {
+                            clientAdapter.AllowPacketFragmentation = _options.AllowPacketFragmentation;
+                        }
+                        else
+                        {
+                            clientAdapter.AllowPacketFragmentation = _options.AllowPacketFragmentationSelector(clientAdapter);
+                        }
                         await clientHandler(clientAdapter).ConfigureAwait(false);
                     }
                 }

--- a/Source/MQTTnet.Server/Options/MqttServerOptionsBuilder.cs
+++ b/Source/MQTTnet.Server/Options/MqttServerOptionsBuilder.cs
@@ -8,6 +8,7 @@ using System.Net.Security;
 using System.Security.Authentication;
 using MQTTnet.Certificates;
 using System.Security.Cryptography.X509Certificates;
+using MQTTnet.Adapter;
 
 // ReSharper disable UnusedMember.Global
 namespace MQTTnet.Server
@@ -136,6 +137,13 @@ namespace MQTTnet.Server
         {
             _options.DefaultEndpointOptions.AllowPacketFragmentation = false;
             _options.TlsEndpointOptions.AllowPacketFragmentation = false;
+            return WithPacketFragmentationSelector(null);
+        }
+
+        public MqttServerOptionsBuilder WithPacketFragmentationSelector(Func<IMqttChannelAdapter, bool> selector)
+        {
+            _options.DefaultEndpointOptions.AllowPacketFragmentationSelector = selector;
+            _options.TlsEndpointOptions.AllowPacketFragmentationSelector = selector;
             return this;
         }
 

--- a/Source/MQTTnet.Server/Options/MqttServerTcpEndpointBaseOptions.cs
+++ b/Source/MQTTnet.Server/Options/MqttServerTcpEndpointBaseOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using MQTTnet.Adapter;
 using System.Net;
 using System.Net.Sockets;
 
@@ -30,6 +31,12 @@ namespace MQTTnet.Server
         ///     server the flag must be set to _false_.
         /// </summary>
         public bool AllowPacketFragmentation { get; set; } = true;
+
+        /// <summary>
+        /// Select whether to AllowPacketFragmentation for an <see cref="IMqttChannelAdapter"/>.
+        /// Its priority is higher than the <see cref="AllowPacketFragmentation"/>.
+        /// </summary>
+        public Func<IMqttChannelAdapter, bool> AllowPacketFragmentationSelector { get; set; }
 
         /// <summary>
         ///     Gets or sets the TCP keep alive interval.

--- a/Source/MQTTnet.Tests/Mockups/MemoryMqttChannel.cs
+++ b/Source/MQTTnet.Tests/Mockups/MemoryMqttChannel.cs
@@ -34,6 +34,8 @@ namespace MQTTnet.Tests.Mockups
 
         public X509Certificate2 ClientCertificate { get; }
 
+        public bool IsWebSocketConnection => false;
+
         public Task ConnectAsync(CancellationToken cancellationToken)
         {
             return CompletedTask.Instance;

--- a/Source/MQTTnet.Tests/Server/Events_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Events_Tests.cs
@@ -29,6 +29,14 @@ namespace MQTTnet.Tests.Server
                     return CompletedTask.Instance;
                 };
 
+                ValidatingConnectionEventArgs validatingEventArgs = null;
+                server.ValidatingConnectionAsync += e =>
+                {
+                    validatingEventArgs = e;
+                    return CompletedTask.Instance;
+                };
+
+
                 await testEnvironment.ConnectClient(o => o.WithCredentials("TheUser"));
 
                 await LongTestDelay();
@@ -39,6 +47,10 @@ namespace MQTTnet.Tests.Server
                 Assert.IsTrue(eventArgs.RemoteEndPoint.ToString().Contains("127.0.0.1"));
                 Assert.AreEqual(MqttProtocolVersion.V311, eventArgs.ProtocolVersion);
                 Assert.AreEqual("TheUser", eventArgs.UserName);
+
+                Assert.AreEqual("TheUser", validatingEventArgs.UserName);
+                Assert.IsFalse(validatingEventArgs.IsSecureConnection);
+                Assert.IsFalse(validatingEventArgs.IsWebSocketConnection);
             }
         }
 

--- a/Source/MQTTnet/Adapter/IMqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/IMqttChannelAdapter.cs
@@ -24,6 +24,8 @@ public interface IMqttChannelAdapter : IDisposable
 
     bool IsSecureConnection { get; }
 
+    bool IsWebSocketConnection { get; }
+
     MqttPacketFormatterAdapter PacketFormatterAdapter { get; }
 
     Task ConnectAsync(CancellationToken cancellationToken);

--- a/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
+++ b/Source/MQTTnet/Adapter/MqttChannelAdapter.cs
@@ -56,6 +56,8 @@ public sealed class MqttChannelAdapter : Disposable, IMqttChannelAdapter
 
     public bool IsSecureConnection => _channel.IsSecureConnection;
 
+    public bool IsWebSocketConnection => _channel.IsWebSocketConnection;
+
     public MqttPacketFormatterAdapter PacketFormatterAdapter { get; }
 
     public MqttPacketInspector PacketInspector { get; set; }

--- a/Source/MQTTnet/Channel/IMqttChannel.cs
+++ b/Source/MQTTnet/Channel/IMqttChannel.cs
@@ -18,6 +18,8 @@ public interface IMqttChannel : IDisposable
 
     bool IsSecureConnection { get; }
 
+    bool IsWebSocketConnection { get; }
+
     Task ConnectAsync(CancellationToken cancellationToken);
 
     Task DisconnectAsync(CancellationToken cancellationToken);

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -53,6 +53,8 @@ namespace MQTTnet.Implementations
 
         public bool IsSecureConnection { get; }
 
+        public bool IsWebSocketConnection => false;
+
         public async Task ConnectAsync(CancellationToken cancellationToken)
         {
             CrossPlatformSocket socket = null;

--- a/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttWebSocketChannel.cs
@@ -41,6 +41,8 @@ namespace MQTTnet.Implementations
 
         public bool IsSecureConnection { get; private set; }
 
+        public bool IsWebSocketConnection => true;
+
         public async Task ConnectAsync(CancellationToken cancellationToken)
         {
             var uri = _options.Uri;


### PR DESCRIPTION
When I was developing the WebSocket capability of #2103, I found that the AllowPacketFragmentation of MqttServerTcpEndpointBaseOptions could not be perfectly adapted. We need to dynamically choose whether to use PacketFragmentation based on whether the IMqttChannelAdapter is a WebSocket connection, rather than simply true or false.

I also considered adding the AllowPacketFragmentationSelector option to MQTTnet.AspNetCore, but considering that MQTTnet.Server actually needs this option capability, I think it is most appropriate to add it to MqttServerTcpEndpointBaseOptions.

AllowPacketFragmentationSelector is a nullable property with a higher priority than the AllowPacketFragmentation property. It exposes the IMqttChannelAdapter to the implementer of the selector. We need to add an IsWebSocketConnection property to the IMqttChannelAdapter.

```
/// <summary>
///     Usually the MQTT packets can be send partially. This is done by using multiple TCP packets
///     or WebSocket frames etc. Unfortunately not all clients do support this feature and
///     will close the connection when receiving such packets. If such clients are connecting to this
///     server the flag must be set to _false_.
/// </summary>
public bool AllowPacketFragmentation { get; set; } = true;

/// <summary>
/// Select whether to AllowPacketFragmentation for an <see cref="IMqttChannelAdapter"/>.
/// Its priority is higher than the <see cref="AllowPacketFragmentation"/>.
/// </summary>
public Func<IMqttChannelAdapter, bool> AllowPacketFragmentationSelector { get; set; }
```

Currently I have only adapted MAllowPacketFragmentationSelector for MQTTnet.Server, because it doesn't make much sense to adapt it for the current branch of MQTTnet.AspNetCore, and it needs to be adapted after #2103.