### PR TITLE
Unused parameter in WithTryPrivate causing client to send incorrect version byte in header.

### DIFF
--- a/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
+++ b/Source/MQTTnet/Formatter/V3/MqttV3PacketFormatter.cs
@@ -18,9 +18,9 @@ namespace MQTTnet.Formatter.V3
     {
         const int FixedHeaderSize = 1;
 
-        static readonly MqttDisconnectPacket DisconnectPacket = new MqttDisconnectPacket();
+        static readonly MqttDisconnectPacket DisconnectPacket = new();
 
-        readonly MqttBufferReader _bufferReader = new MqttBufferReader();
+        readonly MqttBufferReader _bufferReader = new();
         readonly MqttBufferWriter _bufferWriter;
         readonly MqttProtocolVersion _mqttProtocolVersion;
 
@@ -68,10 +68,8 @@ namespace MQTTnet.Formatter.V3
                     {
                         return DecodeConnAckPacketV311(receivedMqttPacket.Body);
                     }
-                    else
-                    {
-                        return DecodeConnAckPacket(receivedMqttPacket.Body);
-                    }
+
+                    return DecodeConnAckPacket(receivedMqttPacket.Body);
                 case MqttControlPacketType.Disconnect:
                     return DisconnectPacket;
 
@@ -105,10 +103,6 @@ namespace MQTTnet.Formatter.V3
             {
                 payload = publishPacket.Payload;
                 remainingLength += (uint)payload.Length;
-            }
-            else
-            {
-                publishPacket = null;
             }
 
             var remainingLengthSize = MqttBufferWriter.GetVariableByteIntegerSize(remainingLength);
@@ -481,7 +475,16 @@ namespace MQTTnet.Formatter.V3
             ValidateConnectPacket(packet);
 
             bufferWriter.WriteString("MQTT");
-            bufferWriter.WriteByte(4); // 3.1.2.2 Protocol Level 4
+
+            // 3.1.2.2 Protocol Level 4
+            var protocolVersion = 4;
+
+            if (packet.TryPrivate)
+            {
+                protocolVersion |= 0x80;
+            }
+
+            bufferWriter.WriteByte((byte)protocolVersion);
 
             byte connectFlags = 0x0;
             if (packet.CleanSession)
@@ -552,19 +555,15 @@ namespace MQTTnet.Formatter.V3
                     {
                         return EncodeConnectPacketV311(connectPacket, bufferWriter);
                     }
-                    else
-                    {
-                        return EncodeConnectPacket(connectPacket, bufferWriter);
-                    }
+
+                    return EncodeConnectPacket(connectPacket, bufferWriter);
                 case MqttConnAckPacket connAckPacket:
                     if (_mqttProtocolVersion == MqttProtocolVersion.V311)
                     {
                         return EncodeConnAckPacketV311(connAckPacket, bufferWriter);
                     }
-                    else
-                    {
-                        return EncodeConnAckPacket(connAckPacket, bufferWriter);
-                    }
+
+                    return EncodeConnAckPacket(connAckPacket, bufferWriter);
                 case MqttDisconnectPacket _:
                     return EncodeEmptyPacket(MqttControlPacketType.Disconnect);
                 case MqttPingReqPacket _:

--- a/Source/MQTTnet/Options/MqttClientOptions.cs
+++ b/Source/MQTTnet/Options/MqttClientOptions.cs
@@ -127,7 +127,7 @@ public sealed class MqttClientOptions
     ///         connect properly.
     ///     </remarks>
     /// </summary>
-    public bool TryPrivate { get; set; } = true;
+    public bool TryPrivate { get; set; } // Implementation in Mosquitto: https://github.com/eclipse-mosquitto/mosquitto/blob/3cbe805e71ac41a2a20cc9b2ea6b3b619f49554a/lib/send_connect.c#L153
 
     /// <summary>
     ///     Gets or sets the user properties.

--- a/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
+++ b/Source/MQTTnet/Options/MqttClientOptionsBuilder.cs
@@ -361,9 +361,9 @@ public sealed class MqttClientOptionsBuilder
     ///     Not all brokers support this feature so it may be necessary to set it to false if your bridge does not connect
     ///     properly.
     /// </summary>
-    public MqttClientOptionsBuilder WithTryPrivate(bool tryPrivate = true)
+    public MqttClientOptionsBuilder WithTryPrivate(bool value = true)
     {
-        _options.TryPrivate = true;
+        _options.TryPrivate = value;
         return this;
     }
 

--- a/Source/MQTTnet/Options/MqttClientOptionsValidator.cs
+++ b/Source/MQTTnet/Options/MqttClientOptionsValidator.cs
@@ -17,7 +17,11 @@ public static class MqttClientOptionsValidator
 
         if (options.ProtocolVersion == MqttProtocolVersion.V500)
         {
-            // Everything is supported.
+            if (options.TryPrivate)
+            {
+                throw new NotSupportedException("Feature TryPrivate only works with MQTT version 3.1 and 3.1.1.");
+            }
+
             return;
         }
 


### PR DESCRIPTION
Closes #2122 
As described in the issue, the MQTTNet.Client sends incorrect version in the connect header, causing the server to respond with an unsupported protocol exception.

Digging into the encoding code, it turns out the issue is rooted in the EncodeConnectPacket method in MqttV3PacketFormatter.

If TryPrivate is true (default), a bitwise OR operation is applied to the protocol version (I don't know why this is done).
```
var protocolVersion = 3;
if (packet.TryPrivate)
{
    protocolVersion |= 0x80;
}

bufferWriter.WriteByte((byte)protocolVersion);
```

This results in the connect header containing  an incorrect version:
`(hex): 10 df 04 00 06 4d 51 49 73 64 70 (83) 82 00 0f 00`
Instead of the expected
`(hex): 10 df 04 00 06 4d 51 49 73 64 70 (03) 82 00 0f 00`

After fixing the unused parameter in WithTryPrivate and using .WithTryPrivate(false), the connection is successful and no longer throws an UnsupportedProtocolVersion exception.