### PR TITLE
Add ability to get session from server by client id

### DIFF
--- a/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
+++ b/Source/MQTTnet.Server/Internal/MqttClientSessionsManager.cs
@@ -311,6 +311,25 @@ public sealed class MqttClientSessionsManager : ISubscriptionChangedNotification
         return Task.FromResult((IList<MqttClientStatus>)result);
     }
 
+    public Task<MqttSessionStatus> GetSessionStatus(string id)
+    {
+        _sessionsManagementLock.EnterReadLock();
+        try
+        {
+            if (!_sessionsStorage.TryGetSession(id, out var session))
+            {
+                throw new InvalidOperationException($"Session with ID '{id}' not found.");
+            }
+
+            var sessionStatus = new MqttSessionStatus(session);
+            return Task.FromResult(sessionStatus);
+        }
+        finally
+        {
+            _sessionsManagementLock.ExitReadLock();
+        }
+    }
+
     public Task<IList<MqttSessionStatus>> GetSessionsStatus()
     {
         var result = new List<MqttSessionStatus>();

--- a/Source/MQTTnet.Server/MqttServer.cs
+++ b/Source/MQTTnet.Server/MqttServer.cs
@@ -237,6 +237,13 @@ public class MqttServer : Disposable
         return _clientSessionsManager.GetSessionsStatus();
     }
 
+    public Task<MqttSessionStatus> GetSessionAsync(string id)
+    {
+        ThrowIfNotStarted();
+
+        return _clientSessionsManager.GetSessionStatus(id);
+    }
+
     public Task InjectApplicationMessage(InjectedMqttApplicationMessage injectedApplicationMessage, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(injectedApplicationMessage);


### PR DESCRIPTION
Hi there!
Currently it's only possible to get all the sessions from the server object. This small PR also adds the ability to get a single session by it's id.
This is helpful in scenarious when the MQTTNet server is used as as a frontend and it's always needed to get the specific session and inject some messages to it.