### PR TITLE
Remove "MQTTv5 only" in documentation comments for `MqttClientConnectResult.IsSessionPresent` and `MqttClientConnectResult.ResultCode`

### DIFF
--- a/Source/MQTTnet/Connecting/MqttClientConnectResult.cs
+++ b/Source/MQTTnet/Connecting/MqttClientConnectResult.cs
@@ -30,7 +30,6 @@ public sealed class MqttClientConnectResult
 
     /// <summary>
     ///     Gets a value indicating whether a session was already available or not.
-    ///     MQTTv5 only.
     /// </summary>
     public bool IsSessionPresent { get; internal set; }
 

--- a/Source/MQTTnet/Connecting/MqttClientConnectResult.cs
+++ b/Source/MQTTnet/Connecting/MqttClientConnectResult.cs
@@ -57,7 +57,6 @@ public sealed class MqttClientConnectResult
 
     /// <summary>
     ///     Gets the result code.
-    ///     MQTTv5 only.
     /// </summary>
     public MqttClientConnectResultCode ResultCode { get; internal set; }
 


### PR DESCRIPTION
On first glance these properties seem to me to be available in the 3.1.1 standard and available in the MQTTnet implementation.

References:
* [OASIS Standard](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718035)
* [MQTTnet source code](https://github.com/dotnet/MQTTnet/blob/93a9d8d1dbe8dde2b7d79a37c873fae13b4f4797/Source/MQTTnet/Connecting/MqttClientConnectResultFactory.cs#L75)