### PR TITLE
Backport of: 2132 Fix support for enhanced authentication

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,1 +1,3 @@
 * Client: Fixed wrong timeout for keep alive check (thanks to @Erw1nT, #2129)
+* Client: Fixed extended authentication (thanks to @chkr1011, #2132).
+* Server: Fixed extended authentication (thanks to @chkr1011, #2132).

--- a/Source/MQTTnet/Client/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeContext.cs
+++ b/Source/MQTTnet/Client/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeContext.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using MQTTnet.Packets;
 using MQTTnet.Protocol;
 
@@ -11,7 +12,7 @@ namespace MQTTnet.Client
 {
     public class MqttExtendedAuthenticationExchangeContext
     {
-        public MqttExtendedAuthenticationExchangeContext(MqttAuthPacket authPacket, MqttClient client)
+        public MqttExtendedAuthenticationExchangeContext(MqttAuthPacket authPacket, MqttClient client, CancellationToken cancellationToken)
         {
             if (authPacket == null) throw new ArgumentNullException(nameof(authPacket));
 
@@ -22,6 +23,7 @@ namespace MQTTnet.Client
             UserProperties = authPacket.UserProperties;
 
             Client = client ?? throw new ArgumentNullException(nameof(client));
+            CancellationToken = cancellationToken;
         }
 
         /// <summary>
@@ -58,5 +60,10 @@ namespace MQTTnet.Client
         public List<MqttUserProperty> UserProperties { get; }
 
         public MqttClient Client { get; }
+
+        /// <summary>
+        /// The cancellation token passed to the operation being authenticated (e.g. ConnectAsync).
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
     }
 }

--- a/Source/MQTTnet/Client/Options/MqttClientOptionsValidator.cs
+++ b/Source/MQTTnet/Client/Options/MqttClientOptionsValidator.cs
@@ -68,8 +68,13 @@ namespace MQTTnet.Client
                 Throw(nameof(options.AuthenticationMethod));
             }
 
+            if (options.ExtendedAuthenticationExchangeHandler != null)
+            {
+                Throw(nameof(options.ExtendedAuthenticationExchangeHandler));
+            }
+
             // Will relevant properties.
-            
+
             if (options.WillPayloadFormatIndicator != MqttPayloadFormatIndicator.Unspecified)
             {
                 Throw(nameof(options.WillPayloadFormatIndicator));

--- a/Source/MQTTnet/MqttFactory.cs
+++ b/Source/MQTTnet/MqttFactory.cs
@@ -135,6 +135,11 @@ namespace MQTTnet
             return new MqttClient(clientAdapterFactory, logger);
         }
 
+        public MqttExtendedAuthenticationExchangeOptionsFactory CreateMqttExtendedAuthenticationExchangeOptionsBuilder()
+        {
+            return new MqttExtendedAuthenticationExchangeOptionsFactory();
+        }
+
         public MqttServer CreateMqttServer(MqttServerOptions options)
         {
             return CreateMqttServer(options, DefaultLogger);

--- a/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeOptions.cs
+++ b/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeOptions.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using MQTTnet.Packets;
+using System.Collections.Generic;
+
+namespace MQTTnet.Server
+{
+    public sealed class MqttExtendedAuthenticationExchangeOptions
+    {
+        public byte[] AuthenticationData { get; set; }
+
+        public string ReasonString { get; set; }
+
+        public List<MqttUserProperty> UserProperties { get; set; }
+    }
+}

--- a/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeOptionsFactory.cs
+++ b/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeOptionsFactory.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using System;
+using MQTTnet.Packets;
+
+namespace MQTTnet.Server
+{
+    public sealed class MqttExtendedAuthenticationExchangeOptionsFactory
+    {
+        readonly MqttExtendedAuthenticationExchangeOptions _options = new MqttExtendedAuthenticationExchangeOptions();
+
+        public MqttExtendedAuthenticationExchangeOptions Build()
+        {
+            return _options;
+        }
+
+        public MqttExtendedAuthenticationExchangeOptionsFactory WithAuthenticationData(byte[] authenticationData)
+        {
+            _options.AuthenticationData = authenticationData;
+
+            return this;
+        }
+
+        public MqttExtendedAuthenticationExchangeOptionsFactory WithAuthenticationData(string authenticationData)
+        {
+            if (authenticationData == null)
+            {
+                _options.AuthenticationData = null;
+            }
+            else
+            {
+                _options.AuthenticationData = Encoding.UTF8.GetBytes(authenticationData);
+            }
+
+            return this;
+        }
+
+        public MqttExtendedAuthenticationExchangeOptionsFactory WithReasonString(string reasonString)
+        {
+            _options.ReasonString = reasonString;
+
+            return this;
+        }
+
+        public MqttExtendedAuthenticationExchangeOptionsFactory WithUserProperties(List<MqttUserProperty> userProperties)
+        {
+            _options.UserProperties = userProperties;
+
+            return this;
+        }
+
+        public MqttExtendedAuthenticationExchangeOptionsFactory WithUserProperty(string name, string value)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (_options.UserProperties == null)
+            {
+                _options.UserProperties = new List<MqttUserProperty>();
+            }
+
+            _options.UserProperties.Add(new MqttUserProperty(name, value));
+
+            return this;
+        }
+    }
+}

--- a/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeResult.cs
+++ b/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeResult.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using MQTTnet.Packets;
+using System.Collections.Generic;
+
+namespace MQTTnet.Server
+{
+    public sealed class MqttExtendedAuthenticationExchangeResult
+    {
+        public string ReasonString { get; set; }
+
+        public List<MqttUserProperty> UserProperties { get; set; }
+
+        public byte[] AuthenticationData { get; set; }
+    }
+}

--- a/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeResultFactory.cs
+++ b/Source/MQTTnet/Server/ExtendedAuthenticationExchange/MqttExtendedAuthenticationExchangeResultFactory.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using MQTTnet.Packets;
+using System;
+
+namespace MQTTnet.Server
+{
+    public static class MqttExtendedAuthenticationExchangeResultFactory
+    {
+        public static MqttExtendedAuthenticationExchangeResult Create(MqttAuthPacket authPacket)
+        {
+            if (authPacket == null)
+            {
+                throw new ArgumentNullException(nameof(authPacket));
+            }
+
+            return new MqttExtendedAuthenticationExchangeResult
+            {
+                AuthenticationData = authPacket.AuthenticationData,
+
+                ReasonString = authPacket.ReasonString,
+                UserProperties = authPacket.UserProperties
+            };
+        }
+
+        public static MqttExtendedAuthenticationExchangeResult Create(MqttDisconnectPacket disconnectPacket)
+        {
+            if (disconnectPacket == null)
+            {
+                throw new ArgumentNullException(nameof(disconnectPacket));
+            }
+
+            return new MqttExtendedAuthenticationExchangeResult
+            {
+                AuthenticationData = null,
+                ReasonString = disconnectPacket.ReasonString,
+                UserProperties = disconnectPacket.UserProperties
+
+                // SessionExpiryInterval makes no sense because the connection is not yet made!
+                // ServerReferences makes no sense when the client initiated a DISCONNECT!
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR is a backport of #2132 for the version 4 library.

This PR has a number of changes as compared to the PR on which it is based. Since this PR is a fix for the v4 library I stuck with the original "ExtendedAuthenticationExchange" naming convention that was used in the v4 library instead of the more correct "EnhancedAuthentication" naming convention used in the v5 library.

Additionally I tried to avoid any changes to existing interfaces/method signatures that would cause breaking changes. The PR on which these changes are based has many breaking changes as compared to the v4 library.

My company is unable to use the v5 library because we are constrained by having to support the .Net Framework, but we need to be able to authenticate clients using Enhanced Authentication.

This PR addresses the following issues:
* #2029
* #1805
* #2095