### PR TITLE
Client: Tolerate late acknowledgement packets (#2078, #2079)

### DIFF
--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
@@ -870,4 +870,109 @@ public sealed class MqttClient_Tests : BaseTestClass
         Assert.IsTrue(client1.TryPingAsync().GetAwaiter().GetResult());
         Assert.IsFalse(disconnectedFired);
     }
+
+    // Regression test for issue #2079.
+    // A late PUBACK (one whose matching publish request was already cancelled or timed
+    // out client-side) must NOT raise a protocol violation and must NOT disconnect the
+    // client. Before the fix, the client received the late PUBACK, failed to find a
+    // waiter and threw a MqttProtocolViolationException, tearing down the connection.
+    [TestMethod]
+    [DataRow(MqttQualityOfServiceLevel.AtLeastOnce)]
+    [DataRow(MqttQualityOfServiceLevel.ExactlyOnce)]
+    public async Task Cancelled_Publish_Does_Not_Disconnect_Client(MqttQualityOfServiceLevel qos)
+    {
+        using var testEnvironment = new TestEnvironment(TestContext);
+        var server = await testEnvironment.StartServer();
+
+        // Delay the broker's acknowledgement long enough for the publish caller to give
+        // up. When the caller's cancellation token fires the awaitable is removed; the
+        // (slightly later) PUBACK / PUBREC then arrives without a matching waiter.
+        server.InterceptingPublishAsync += async e =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+        };
+
+        var client = await testEnvironment.ConnectClient();
+
+        var disconnected = false;
+        client.DisconnectedAsync += _ =>
+        {
+            disconnected = true;
+            return CompletedTask.Instance;
+        };
+
+        var message = new MqttApplicationMessageBuilder().WithTopic("late-ack").WithQualityOfServiceLevel(qos).Build();
+
+        using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250)))
+        {
+            await Assert.ThrowsExactlyAsync<MqttCommunicationTimedOutException>(() => client.PublishAsync(message, cts.Token));
+        }
+
+        // Wait long enough for the delayed broker acknowledgement to come back.
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        Assert.IsFalse(disconnected, "Client must not disconnect when a late acknowledgement arrives.");
+        Assert.IsTrue(client.IsConnected, "Client must still be connected after a late acknowledgement.");
+
+        // The connection must remain usable for further publishes.
+        var followUp = new MqttApplicationMessageBuilder().WithTopic("late-ack").WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtMostOnce).Build();
+        await client.PublishAsync(followUp);
+    }
+
+    // Regression test for issue #2078.
+    // The MqttClient must support concurrent publishes from multiple threads without
+    // dropping messages, mismatching acknowledgements or disconnecting the client.
+    [TestMethod]
+    [DataRow(MqttQualityOfServiceLevel.AtMostOnce)]
+    [DataRow(MqttQualityOfServiceLevel.AtLeastOnce)]
+    [DataRow(MqttQualityOfServiceLevel.ExactlyOnce)]
+    public async Task Concurrent_Publish_From_Multiple_Threads(MqttQualityOfServiceLevel qos)
+    {
+        const int Threads = 8;
+        const int MessagesPerThread = 250;
+
+        using var testEnvironment = new TestEnvironment(TestContext);
+        await testEnvironment.StartServer();
+
+        var publisher = await testEnvironment.ConnectClient();
+
+        var subscriber = await testEnvironment.ConnectClient();
+        var receivedCount = 0;
+        subscriber.ApplicationMessageReceivedAsync += _ =>
+        {
+            Interlocked.Increment(ref receivedCount);
+            return CompletedTask.Instance;
+        };
+        await subscriber.SubscribeAsync("concurrent/#", qos);
+
+        var disconnected = false;
+        publisher.DisconnectedAsync += _ =>
+        {
+            disconnected = true;
+            return CompletedTask.Instance;
+        };
+
+        var tasks = Enumerable.Range(0, Threads).Select(threadIndex => Task.Run(async () =>
+        {
+            for (var i = 0; i < MessagesPerThread; i++)
+            {
+                var message = new MqttApplicationMessageBuilder()
+                    .WithTopic($"concurrent/{threadIndex}/{i}")
+                    .WithPayload(BitConverter.GetBytes(i))
+                    .WithQualityOfServiceLevel(qos)
+                    .Build();
+
+                await publisher.PublishAsync(message);
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        // Allow the broker to deliver any in-flight messages to the subscriber.
+        SpinWait.SpinUntil(() => receivedCount >= Threads * MessagesPerThread, TimeSpan.FromSeconds(30));
+
+        Assert.IsFalse(disconnected, "Publisher must not disconnect during concurrent publishes.");
+        Assert.IsTrue(publisher.IsConnected);
+        Assert.AreEqual(Threads * MessagesPerThread, receivedCount);
+    }
 }

--- a/Source/MQTTnet/IMqttClient.cs
+++ b/Source/MQTTnet/IMqttClient.cs
@@ -2,6 +2,21 @@ using MQTTnet.Diagnostics.PacketInspection;
 
 namespace MQTTnet;
 
+/// <summary>
+/// Represents an MQTT client.
+/// <para>
+/// Instances of <see cref="IMqttClient" /> are safe for concurrent use: <see cref="PublishAsync" />,
+/// <see cref="SubscribeAsync" />, <see cref="UnsubscribeAsync" /> and <see cref="PingAsync" /> may be
+/// invoked from multiple threads at the same time. Outgoing packets are serialized internally so
+/// that they reach the network in well-formed order, and incoming acknowledgements are routed back
+/// to the corresponding caller via the packet identifier.
+/// </para>
+/// <para>
+/// <see cref="ConnectAsync" /> and <see cref="DisconnectAsync" /> must not be called concurrently
+/// with each other or with publish/subscribe operations. Coordinate connection lifecycle changes on
+/// a single thread.
+/// </para>
+/// </summary>
 public interface IMqttClient : IDisposable
 {
     event Func<MqttApplicationMessageReceivedEventArgs, Task> ApplicationMessageReceivedAsync;

--- a/Source/MQTTnet/MqttClient.cs
+++ b/Source/MQTTnet/MqttClient.cs
@@ -954,6 +954,21 @@ public sealed class MqttClient : Disposable, IMqttClient
                 case MqttPublishPacket publishPacket:
                     EnqueueReceivedPublishPacket(publishPacket);
                     break;
+                case MqttPubAckPacket _:
+                case MqttPubCompPacket _:
+                case MqttSubAckPacket _:
+                case MqttUnsubAckPacket _:
+                    // Acknowledgement packets are dispatched to the awaiter that issued the
+                    // matching request. If no awaiter is registered (for example because the
+                    // request was cancelled or timed out client-side before the broker replied)
+                    // the late acknowledgement is harmless and must NOT terminate the connection.
+                    // See issues #2078 and #2079.
+                    if (!_packetDispatcher.TryDispatch(packet))
+                    {
+                        _logger.Warning("Received {0} for an unknown packet identifier. Probably the matching request was cancelled or timed out.", packet.GetType().Name);
+                    }
+
+                    break;
                 case MqttPubRecPacket pubRecPacket:
                     await ProcessReceivedPubRecPacket(pubRecPacket, cancellationToken).ConfigureAwait(false);
                     break;

--- a/Source/ReleaseNotes.md
+++ b/Source/ReleaseNotes.md
@@ -2,6 +2,7 @@
 * Core: Performance improvements
 * Core: Added validations for variable byte integers which do not match the .NET uint perfectly
 * Client: Added support for pre-encoded UTF-8 binary buffers for user properties (#2228, thanks to @koepalex)
+* Client: Late acknowledgement packets (PUBACK, PUBCOMP, SUBACK, UNSUBACK) for cancelled or timed-out requests no longer trigger a protocol violation and tear down the connection (#2078, #2079)
 * Server: Improved performance of retained messages when no event handler is attached (#2093, thanks to @zhaowgit)
 * Server: The event `InterceptingClientEnqueue` is now also called for retained messages (BREAKING CHANGE!)
 * Server: The local end point is now also exposed in the channel adapter (#2179)


### PR DESCRIPTION
Fixes #2078
Fixes #2079

## Problem

When a `PublishAsync` / `SubscribeAsync` / `UnsubscribeAsync` call is cancelled or times out client-side, its awaitable is removed from `MqttPacketDispatcher`. If the broker''s matching `PUBACK` / `PUBCOMP` / `SUBACK` / `UNSUBACK` arrives slightly later it falls through the `default` case in `MqttClient.TryProcessReceivedPacket`, raises `MqttProtocolViolationException("Received packet ''...'' at an unexpected time.")`, and tears down the connection.

This surfaced as:
- **#2079** — sporadic `MqttProtocolViolationException` on a tiny fraction of QoS 1 publishes when sending high volumes (~100k messages).
- **#2078** — `MqttClient` appearing unsafe under concurrent publishes from multiple threads.

## Why #2078 is the same root cause (not a missing lock)

The two issues look different but share one bug. The client was already correctly synchronised at every relevant layer; concurrency just made the late-ack race far more likely to be hit.

What was already protected:

| Step | Protected | How |
| --- | --- | --- |
| `MqttPacketIdentifierProvider.GetNextPacketIdentifier` | yes | `lock (_syncRoot)` — each caller gets a unique ID |
| `MqttPacketDispatcher.AddAwaitable` | yes | `lock (_waiters)` |
| `MqttChannelAdapter.SendPacketAsync` | yes | `await _syncRoot.EnterAsync(...)` (`AsyncLock`) — wire bytes never interleave |
| Each caller awaits its own `MqttPacketAwaitable<T>` | yes | Per-call instance |
| Incoming acks routed by packet identifier | yes | `MqttPacketDispatcher.TryDispatch` matches by ID |

So two threads calling `PublishAsync` simultaneously was fine at the locking level. What broke under load was this sequence:

1. Thread A calls `PublishAsync(message, ctsA.Token)` with a tight timeout.
2. The awaitable for packet id `N` is registered, the PUBLISH goes on the wire.
3. `ctsA` fires before the broker''s PUBACK arrives - the awaitable is removed.
4. PUBACK for `N` arrives.
5. **Old behaviour:** dispatcher finds no waiter → `MqttProtocolViolationException` → connection torn down.
6. **Thread B''s** unrelated in-flight publish, sharing the same connection, now also fails.

That is why users perceived "the client breaks when used from multiple threads": one caller''s cancellation killed everyone else''s connection. The same race produced #2079 in a single-threaded high-volume scenario, where a small fraction of publishes get cancelled by their own timeout.

Adding a `SemaphoreSlim` around `PublishAsync` would have been the wrong fix - it would serialise publishes (hurting throughput) without addressing the actual bug, since the late-ack race exists regardless of how many threads are involved.

## Fix

`MqttClient.TryProcessReceivedPacket` now matches `PUBACK` / `PUBCOMP` / `SUBACK` / `UNSUBACK` explicitly. If no awaiter is registered the packet is logged as a warning and dropped, rather than treated as a protocol violation. The connection is preserved. `PUBREC` / `PUBREL` already had spec-compliant handling for unknown identifiers and are unchanged.

`IMqttClient` now documents its concurrency contract: `PublishAsync`, `SubscribeAsync`, `UnsubscribeAsync` and `PingAsync` are safe to invoke concurrently from multiple threads. `ConnectAsync` / `DisconnectAsync` must still be coordinated on a single thread.

## Tests

Two new tests in `MqttClient_Tests`:

- `Cancelled_Publish_Does_Not_Disconnect_Client` (`AtLeastOnce`, `ExactlyOnce`) - uses `InterceptingPublishAsync` to delay the broker''s ack, cancels the publish, and asserts the client stays connected and remains usable. Verified to fail on the unfixed code with `MqttProtocolViolationException`.
- `Concurrent_Publish_From_Multiple_Threads` (`AtMostOnce`, `AtLeastOnce`, `ExactlyOnce`) - 8 threads x 250 messages, asserts no disconnect and that every message is delivered to a subscriber.

Full suite: **487 / 487 passed** locally on `net8.0`.

## Release notes

Entry added to `Source/ReleaseNotes.md`.