### PR TITLE
Fix MQTT v5 topic alias forwarding

### DIFF
--- a/Source/MQTTnet.Server/Internal/MqttConnectedClient.cs
+++ b/Source/MQTTnet.Server/Internal/MqttConnectedClient.cs
@@ -218,6 +218,8 @@ public sealed class MqttConnectedClient : IDisposable
         HandleTopicAlias(publishPacket);
 
         var applicationMessage = MqttApplicationMessageFactory.Create(publishPacket);
+        // Topic aliases are scoped to this network connection and must not be forwarded to other clients.
+        applicationMessage.TopicAlias = 0;
 
         var dispatchApplicationMessageResult =
             await _sessionsManager.DispatchApplicationMessage(Id, UserName, Session.Items, applicationMessage, cancellationToken).ConfigureAwait(false);

--- a/Source/MQTTnet.Tests/MQTTv5/Client_Tests.cs
+++ b/Source/MQTTnet.Tests/MQTTv5/Client_Tests.cs
@@ -114,7 +114,7 @@ public sealed class Client_Tests : BaseTestClass
 
         Assert.IsNotNull(receivedMessage);
         Assert.AreEqual(applicationMessage.Topic, receivedMessage.Topic);
-        Assert.AreEqual(applicationMessage.TopicAlias, receivedMessage.TopicAlias);
+        Assert.AreEqual(0, receivedMessage.TopicAlias);
         Assert.AreEqual(applicationMessage.ContentType, receivedMessage.ContentType);
         Assert.AreEqual(applicationMessage.ResponseTopic, receivedMessage.ResponseTopic);
         Assert.AreEqual(applicationMessage.MessageExpiryInterval, receivedMessage.MessageExpiryInterval);

--- a/Source/MQTTnet.Tests/Server/Topic_Alias_Tests.cs
+++ b/Source/MQTTnet.Tests/Server/Topic_Alias_Tests.cs
@@ -34,6 +34,7 @@ public sealed class Topic_Alias_Tests : BaseTestClass
         await testEnvironment.StartServer();
 
         var receivedTopics = new List<string>();
+        var receivedTopicAliases = new List<ushort>();
 
         var c1 = await testEnvironment.ConnectClient(options => options.WithProtocolVersion(MqttProtocolVersion.V500));
         c1.ApplicationMessageReceivedAsync += e =>
@@ -41,6 +42,7 @@ public sealed class Topic_Alias_Tests : BaseTestClass
             lock (receivedTopics)
             {
                 receivedTopics.Add(e.ApplicationMessage.Topic);
+                receivedTopicAliases.Add(e.ApplicationMessage.TopicAlias);
             }
 
             return CompletedTask.Instance;
@@ -68,5 +70,6 @@ public sealed class Topic_Alias_Tests : BaseTestClass
         Assert.HasCount(3, receivedTopics);
         CollectionAssert.AllItemsAreNotNull(receivedTopics);
         Assert.IsTrue(receivedTopics.All(t => t.Equals("this_is_the_topic", System.StringComparison.Ordinal)));
+        Assert.IsTrue(receivedTopicAliases.All(a => a == 0));
     }
 }


### PR DESCRIPTION
Fixes #2199

## Summary

This fixes MQTT v5 topic alias handling in the server publish path.

Topic Alias mappings are scoped to a single network connection. When a client publishes a message with a Topic Alias, the server should resolve that alias for the inbound connection, but it should not forward the same Topic Alias to subscribers on separate client connections.

## Changes

- Clears `TopicAlias` before dispatching a received application message to subscriber sessions.
- Updates MQTT v5 property forwarding coverage so subscriber messages no longer expect the publisher's alias.
- Extends the server topic alias test to verify subscribers receive resolved topics without forwarded aliases.

## Validation

- `dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --filter "Topic_Alias_Tests|Publish_And_Receive_New_Properties" --no-restore`
- `dotnet build MQTTnet.sln --no-restore`

Note: a full local test run was not clean in this environment due to unrelated TLS credential/runtime/network-sensitive tests.
