### PR TITLE
Fix keep alive ping send timeout disconnect handling

### DIFF
--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
@@ -5,8 +5,12 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using MQTTnet.Adapter;
+using MQTTnet.Diagnostics.Logger;
 using MQTTnet.Exceptions;
 using MQTTnet.Formatter;
 using MQTTnet.Internal;
@@ -452,6 +456,34 @@ public sealed class MqttClient_Tests : BaseTestClass
         {
             Assert.Fail(ex.Message);
         }
+    }
+
+    [TestMethod]
+    public async Task KeepAlive_Ping_Send_Timeout_Raises_Disconnected()
+    {
+        var adapterFactory = new KeepAliveTimeoutAdapterFactory();
+        var disconnected = new TaskCompletionSource<MqttClientDisconnectedEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var client = new MqttClientFactory().CreateMqttClient(adapterFactory);
+        client.DisconnectedAsync += eventArgs =>
+        {
+            disconnected.TrySetResult(eventArgs);
+            return CompletedTask.Instance;
+        };
+
+        var options = new MqttClientOptionsBuilder()
+            .WithTcpServer("localhost")
+            .WithKeepAlivePeriod(TimeSpan.FromSeconds(1))
+            .Build();
+
+        await client.ConnectAsync(options);
+
+        await adapterFactory.Adapter.PingRequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(3));
+        var disconnectedEventArgs = await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+        Assert.IsTrue(disconnectedEventArgs.ClientWasConnected);
+        Assert.IsInstanceOfType<OperationCanceledException>(disconnectedEventArgs.Exception);
+        Assert.IsFalse(client.IsConnected);
     }
 
     [TestMethod]
@@ -974,5 +1006,85 @@ public sealed class MqttClient_Tests : BaseTestClass
         Assert.IsFalse(disconnected, "Publisher must not disconnect during concurrent publishes.");
         Assert.IsTrue(publisher.IsConnected);
         Assert.AreEqual(Threads * MessagesPerThread, receivedCount);
+    }
+
+    sealed class KeepAliveTimeoutAdapterFactory : IMqttClientAdapterFactory
+    {
+        public KeepAliveTimeoutAdapter Adapter { get; private set; }
+
+        public IMqttChannelAdapter CreateClientAdapter(MqttClientOptions options, MqttPacketInspector packetInspector, IMqttNetLogger logger)
+        {
+            Adapter = new KeepAliveTimeoutAdapter(options.ProtocolVersion, options.WriterBufferSize, options.WriterBufferSizeMax);
+            return Adapter;
+        }
+    }
+
+    sealed class KeepAliveTimeoutAdapter : IMqttChannelAdapter
+    {
+        int _connAckReturned;
+
+        public KeepAliveTimeoutAdapter(MqttProtocolVersion protocolVersion, int writerBufferSize, int writerBufferSizeMax)
+        {
+            PacketFormatterAdapter = new MqttPacketFormatterAdapter(protocolVersion, new MqttBufferWriter(writerBufferSize, writerBufferSizeMax));
+        }
+
+        public long BytesReceived { get; }
+
+        public long BytesSent { get; }
+
+        public X509Certificate2 ClientCertificate { get; }
+
+        public EndPoint RemoteEndPoint { get; } = new DnsEndPoint("localhost", 1883);
+
+        public EndPoint LocalEndPoint { get; } = new DnsEndPoint("localhost", 0);
+
+        public bool IsSecureConnection { get; }
+
+        public MqttPacketFormatterAdapter PacketFormatterAdapter { get; }
+
+        public TaskCompletionSource PingRequestReceived { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ConnectAsync(CancellationToken cancellationToken)
+        {
+            return CompletedTask.Instance;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken)
+        {
+            return CompletedTask.Instance;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public async Task<MqttPacket> ReceivePacketAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Exchange(ref _connAckReturned, 1) == 0)
+            {
+                return new MqttConnAckPacket
+                {
+                    ReturnCode = MqttConnectReturnCode.ConnectionAccepted
+                };
+            }
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return null;
+        }
+
+        public void ResetStatistics()
+        {
+        }
+
+        public Task SendPacketAsync(MqttPacket packet, CancellationToken cancellationToken)
+        {
+            if (packet is MqttPingReqPacket)
+            {
+                PingRequestReceived.TrySetResult();
+                return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+
+            return CompletedTask.Instance;
+        }
     }
 }

--- a/Source/MQTTnet/MqttClient.cs
+++ b/Source/MQTTnet/MqttClient.cs
@@ -1064,7 +1064,12 @@ public sealed class MqttClient : Disposable, IMqttClient
             switch (exception)
             {
                 case OperationCanceledException:
-                    return;
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    break;
                 case MqttCommunicationException:
                     _logger.Warning(exception, "Communication error while sending/receiving keep alive packets");
                     break;


### PR DESCRIPTION
Relates to #2248

Summary
This fixes a keep-alive cancellation path where the client can swallow an OperationCanceledException raised while sending PINGREQ.

The keep-alive loop should return silently when the client-wide alive token is canceled during a normal shutdown. However, if the keep-alive ping operation itself is canceled by its timeout token, that indicates a connection failure and should fall through to DisconnectInternal so DisconnectedAsync is raised.

Changes
- Distinguishes client shutdown cancellation from keep-alive ping timeout cancellation.
- Allows keep-alive ping send timeout cancellation to trigger DisconnectInternal.
- Adds a regression test using a fake adapter that accepts CONNECT, then blocks PINGREQ send until the keep-alive timeout cancels it.

Validation
- dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --no-restore -- --filter KeepAlive_Ping_Send_Timeout_Raises_Disconnected
- dotnet build MQTTnet.slnx --no-restore

Notes
The no-PINGRESP path appears to be converted to MqttCommunicationTimedOutException by the packet awaitable. This test covers the OperationCanceledException path where the keep-alive PING send itself is canceled by the timeout token.