### PR TITLE
Fix default TLS certificate validation (BREAKING CHANGE)

### DIFF
--- a/Source/MQTTnet.Tests/MqttTcpChannel_Tests.cs
+++ b/Source/MQTTnet.Tests/MqttTcpChannel_Tests.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using MQTTnet.Implementations;
 
 namespace MQTTnet.Tests;
@@ -12,6 +15,21 @@ namespace MQTTnet.Tests;
 [TestClass]
 public class MqttTcpChannel_Tests
 {
+    [TestMethod]
+    public void Certificate_Validation_Uses_Default_Handler_When_No_Custom_Handler()
+    {
+        var options = new MqttClientOptionsBuilder().WithTcpServer("localhost")
+            .WithTlsOptions(o => o.WithAllowUntrustedCertificates().WithIgnoreCertificateRevocationErrors())
+            .Build();
+
+        var tcpChannel = new MqttTcpChannel(options);
+
+        using var chain = new X509Chain();
+        var isValid = InvokeCertificateValidationCallback(tcpChannel, chain, SslPolicyErrors.RemoteCertificateChainErrors);
+
+        Assert.IsTrue(isValid);
+    }
+
     [TestMethod]
     public async Task Dispose_Channel_While_Used()
     {
@@ -76,5 +94,13 @@ public class MqttTcpChannel_Tests
         {
             ct.Cancel(false);
         }
+    }
+
+    static bool InvokeCertificateValidationCallback(MqttTcpChannel tcpChannel, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+    {
+        var method = typeof(MqttTcpChannel).GetMethod("InternalUserCertificateValidationCallback", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method);
+
+        return (bool)method.Invoke(tcpChannel, [null, null, chain, sslPolicyErrors]);
     }
 }

--- a/Source/MQTTnet/Implementations/MqttTcpChannel.cs
+++ b/Source/MQTTnet/Implementations/MqttTcpChannel.cs
@@ -362,19 +362,14 @@ public sealed class MqttTcpChannel : IMqttChannel
 
     bool InternalUserCertificateValidationCallback(object sender, X509Certificate x509Certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
     {
+        var eventArgs = new MqttClientCertificateValidationEventArgs(x509Certificate, chain, sslPolicyErrors, _tcpOptions);
         var certificateValidationHandler = _tcpOptions?.TlsOptions?.CertificateValidationHandler;
         if (certificateValidationHandler != null)
         {
-            var eventArgs = new MqttClientCertificateValidationEventArgs(x509Certificate, chain, sslPolicyErrors, _tcpOptions);
             return certificateValidationHandler(eventArgs);
         }
 
-        if (_tcpOptions?.TlsOptions?.IgnoreCertificateChainErrors ?? false)
-        {
-            sslPolicyErrors &= ~SslPolicyErrors.RemoteCertificateChainErrors;
-        }
-
-        return sslPolicyErrors == SslPolicyErrors.None;
+        return MqttClientDefaultCertificateValidationHandler.Handle(eventArgs);
     }
 
     X509CertificateCollection LoadCertificates()


### PR DESCRIPTION
Fixes #2233

Summary
This fixes the TCP client TLS certificate validation path so that MQTTnet's default certificate validation handler is used when no custom certificate validation handler is provided.

Previously, MqttTcpChannel had its own fallback logic that only handled IgnoreCertificateChainErrors and otherwise returned sslPolicyErrors == SslPolicyErrors.None. This meant options handled by MqttClientDefaultCertificateValidationHandler, such as AllowUntrustedCertificates and IgnoreCertificateRevocationErrors, were ignored unless users explicitly assigned the default handler themselves.

Changes
- Preserves custom CertificateValidationHandler behavior when supplied.
- Falls back to MqttClientDefaultCertificateValidationHandler.Handle when no custom handler is supplied.
- Adds a regression test covering default-handler fallback for an untrusted certificate chain error.

Validation
- dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --no-restore -- --filter Certificate_Validation_Uses_Default_Handler_When_No_Custom_Handler
- dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --no-restore -- --filter MqttTcpChannel_Tests
- dotnet build MQTTnet.slnx --no-restore
- git diff --check

Notes
The new regression test failed before the production change and passed after it.