### PR TITLE
Fix ASP connection handler startup race

### DIFF
--- a/Source/MQTTnet.AspnetCore/MqttConnectionHandler.cs
+++ b/Source/MQTTnet.AspnetCore/MqttConnectionHandler.cs
@@ -23,6 +23,16 @@ public sealed class MqttConnectionHandler : ConnectionHandler, IMqttServerAdapte
 
     public override async Task OnConnectedAsync(ConnectionContext connection)
     {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        var serverOptions = _serverOptions;
+        var clientHandler = ClientHandler;
+        if (serverOptions == null || clientHandler == null)
+        {
+            connection.Abort();
+            return;
+        }
+
         // required for websocket transport to work
         var transferFormatFeature = connection.Features.Get<ITransferFormatFeature>();
         if (transferFormatFeature != null)
@@ -30,17 +40,15 @@ public sealed class MqttConnectionHandler : ConnectionHandler, IMqttServerAdapte
             transferFormatFeature.ActiveFormat = TransferFormat.Binary;
         }
 
-        var formatter = new MqttPacketFormatterAdapter(new MqttBufferWriter(_serverOptions.WriterBufferSize, _serverOptions.WriterBufferSizeMax));
+        var formatter = new MqttPacketFormatterAdapter(new MqttBufferWriter(serverOptions.WriterBufferSize, serverOptions.WriterBufferSizeMax));
         using var adapter = new MqttConnectionContext(formatter, connection);
-        var clientHandler = ClientHandler;
-        if (clientHandler != null)
-        {
-            await clientHandler(adapter).ConfigureAwait(false);
-        }
+        await clientHandler(adapter).ConfigureAwait(false);
     }
 
     public Task StartAsync(MqttServerOptions options, IMqttNetLogger logger)
     {
+        ArgumentNullException.ThrowIfNull(options);
+
         _serverOptions = options;
 
         return Task.CompletedTask;

--- a/Source/MQTTnet.Tests/ASP/MqttConnectionContextTest.cs
+++ b/Source/MQTTnet.Tests/ASP/MqttConnectionContextTest.cs
@@ -115,6 +115,31 @@ public class MqttConnectionContextTest
         await Assert.ThrowsExactlyAsync<MqttCommunicationException>(() => ctx.ReceivePacketAsync(CancellationToken.None)).ConfigureAwait(false);
     }
 
+    [TestMethod]
+    public async Task ConnectionHandler_Aborts_Connection_When_Server_Not_Started()
+    {
+        var handler = new MqttConnectionHandler();
+        var connection = new AbortTrackingConnectionContext
+        {
+            Transport = new DuplexPipeMockup()
+        };
+
+        await handler.OnConnectedAsync(connection);
+
+        Assert.IsTrue(connection.Aborted);
+    }
+
+    sealed class AbortTrackingConnectionContext : DefaultConnectionContext
+    {
+        public bool Aborted { get; private set; }
+
+        public override void Abort(ConnectionAbortedException abortReason)
+        {
+            Aborted = true;
+            base.Abort(abortReason);
+        }
+    }
+
     sealed class Startup
     {
 #pragma warning disable CA1822


### PR DESCRIPTION
Fixes #2173

Summary
This fixes a startup race in the ASP.NET Core connection handler.

If ASP.NET routes a connection to `MqttConnectionHandler.OnConnectedAsync` before the MQTT server adapter has been started, `_serverOptions` is still null and the handler throws a `NullReferenceException`. The connection should be terminated cleanly instead of remaining in an invalid handler state.

Changes
- Abort incoming ASP.NET Core connections when the MQTT server adapter has not been started or no client handler is wired.
- Read server options and the client handler into locals before constructing the MQTT connection context.
- Add a regression test covering the not-started handler path.

Validation
- `dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --no-restore --filter ConnectionHandler_Aborts_Connection_When_Server_Not_Started`
- `dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~MQTTnet.Tests.ASP`
- `dotnet build MQTTnet.slnx --no-restore`

Note: the solution build completes successfully with existing benchmark warnings about obsolete ASP.NET hosting APIs.