### PR TITLE
Fix keep alive detection during publishing

### DIFF
--- a/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
+++ b/Source/MQTTnet.Tests/Clients/MqttClient/MqttClient_Tests.cs
@@ -487,6 +487,61 @@ public sealed class MqttClient_Tests : BaseTestClass
     }
 
     [TestMethod]
+    public async Task KeepAlive_Timeout_Raises_Disconnected_While_Publishing()
+    {
+        var adapterFactory = new KeepAliveTimeoutAdapterFactory();
+        var disconnected = new TaskCompletionSource<MqttClientDisconnectedEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var client = new MqttClientFactory().CreateMqttClient(adapterFactory);
+        client.DisconnectedAsync += eventArgs =>
+        {
+            disconnected.TrySetResult(eventArgs);
+            return CompletedTask.Instance;
+        };
+
+        var options = new MqttClientOptionsBuilder()
+            .WithTcpServer("localhost")
+            .WithKeepAlivePeriod(TimeSpan.FromSeconds(1))
+            .Build();
+
+        await client.ConnectAsync(options);
+
+        var message = new MqttApplicationMessageBuilder().WithTopic("keep-alive").Build();
+        using var publishCancellation = new CancellationTokenSource();
+        var publishTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (!disconnected.Task.IsCompleted)
+                {
+                    await client.PublishAsync(message, publishCancellation.Token);
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), publishCancellation.Token);
+                }
+            }
+            catch (OperationCanceledException) when (publishCancellation.IsCancellationRequested)
+            {
+            }
+            catch (MqttClientNotConnectedException) when (disconnected.Task.IsCompleted)
+            {
+            }
+        });
+
+        try
+        {
+            var disconnectedEventArgs = await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+            Assert.IsTrue(disconnectedEventArgs.ClientWasConnected);
+            Assert.IsInstanceOfType<OperationCanceledException>(disconnectedEventArgs.Exception);
+            Assert.IsFalse(client.IsConnected);
+        }
+        finally
+        {
+            await publishCancellation.CancelAsync();
+            await publishTask;
+        }
+    }
+
+    [TestMethod]
     public async Task Publish_QoS_1_In_ApplicationMessageReceiveHandler()
     {
         using var testEnvironment = new TestEnvironment(TestContext);

--- a/Source/MQTTnet/MqttClient.cs
+++ b/Source/MQTTnet/MqttClient.cs
@@ -37,6 +37,7 @@ public sealed class MqttClient : Disposable, IMqttClient
     List<MqttUserProperty> _disconnectUserProperties;
 
     Task _keepAlivePacketsSenderTask;
+    DateTime _lastPacketReceivedTimestamp;
     DateTime _lastPacketSentTimestamp;
 
     CancellationTokenSource _mqttClientAlive;
@@ -141,7 +142,7 @@ public sealed class MqttClient : Disposable, IMqttClient
                 return connectResult;
             }
 
-            _lastPacketSentTimestamp = DateTime.UtcNow;
+            _lastPacketReceivedTimestamp = _lastPacketSentTimestamp = DateTime.UtcNow;
 
             var keepAliveInterval = Options.KeepAlivePeriod;
             if (connectResult.ServerKeepAlive > 0)
@@ -786,6 +787,11 @@ public sealed class MqttClient : Disposable, IMqttClient
             packet = await packetTask.ConfigureAwait(false);
         }
 
+        if (packet != null)
+        {
+            _lastPacketReceivedTimestamp = DateTime.UtcNow;
+        }
+
         return packet;
     }
 
@@ -1034,9 +1040,13 @@ public sealed class MqttClient : Disposable, IMqttClient
             while (!cancellationToken.IsCancellationRequested)
             {
                 // Values described here: [MQTT-3.1.2-24].
-                var timeWithoutPacketSent = DateTime.UtcNow - _lastPacketSentTimestamp;
+                var currentTimestamp = DateTime.UtcNow;
+                var timeWithoutPacketReceived = currentTimestamp - _lastPacketReceivedTimestamp;
+                var timeWithoutPacketSent = currentTimestamp - _lastPacketSentTimestamp;
 
-                if (timeWithoutPacketSent > keepAlivePeriod)
+                // Outbound traffic satisfies the MQTT keep-alive requirement, but inbound silence still requires
+                // a ping to detect a half-open connection.
+                if (timeWithoutPacketReceived > keepAlivePeriod || timeWithoutPacketSent > keepAlivePeriod)
                 {
                     using var pingTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 


### PR DESCRIPTION
Fixes #2244

## Summary

This fixes keep-alive detection when a client continuously publishes QoS 0 messages over a half-open connection.

The keep-alive loop previously considered only the last packet sent. Periodic publishes kept refreshing that timestamp even when the broker returned no traffic, so the client never sent a PINGREQ and `DisconnectedAsync` could remain silent indefinitely.

## Changes

- Track the timestamp of the last packet received from the broker.
- Send a keep-alive ping when either outbound MQTT traffic is overdue or no inbound traffic has been observed for the keep-alive interval.
- Add a deterministic regression test using an adapter that accepts publishes but lets PINGREQ time out.

## Validation

- `dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --no-restore --filter "KeepAlive_Timeout_Raises_Disconnected_While_Publishing|KeepAlive_Ping_Send_Timeout_Raises_Disconnected|Publish_QoS_0_Over_Period_Exceeding_KeepAlive"`
- `dotnet test --project Source\MQTTnet.Tests\MQTTnet.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~MQTTnet.Tests.Clients.MqttClient.MqttClient_Tests`
- `dotnet build MQTTnet.slnx --no-restore`

The solution build succeeds with the existing ASP.NET benchmark deprecation warnings.